### PR TITLE
Compiler fixes for VS2010

### DIFF
--- a/src/base64/base64.cpp
+++ b/src/base64/base64.cpp
@@ -93,7 +93,7 @@ std::string base64_decode(std::string const& encoded_string) {
     char_array_4[i++] = encoded_string[in_]; in_++;
     if (i ==4) {
       for (i = 0; i <4; i++)
-        char_array_4[i] = base64_chars.find(char_array_4[i]);
+        char_array_4[i] = static_cast<unsigned char>(base64_chars.find(char_array_4[i]));
 
       char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
       char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
@@ -110,7 +110,7 @@ std::string base64_decode(std::string const& encoded_string) {
       char_array_4[j] = 0;
 
     for (j = 0; j <4; j++)
-      char_array_4[j] = base64_chars.find(char_array_4[j]);
+      char_array_4[j] = static_cast<unsigned char>(base64_chars.find(char_array_4[j]));
 
     char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
     char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -49,6 +49,10 @@
 #include <queue>
 #include <set>
 
+#ifdef min
+	#undef min
+#endif // #ifdef min
+
 namespace websocketpp {
 
 class endpoint_base;
@@ -63,8 +67,7 @@ template <
 class connection 
  : public role< connection<endpoint,role,socket> >,
    public socket< connection<endpoint,role,socket> >,
-   public boost::enable_shared_from_this< connection<endpoint,role,socket> >,
-   boost::noncopyable
+   public boost::enable_shared_from_this< connection<endpoint,role,socket> >
 {
 public:
     typedef connection_traits< connection<endpoint,role,socket> > traits;

--- a/src/endpoint.hpp
+++ b/src/endpoint.hpp
@@ -79,8 +79,7 @@ template <
 class endpoint 
  : public endpoint_base,
    public role< endpoint<role,socket,logger> >,
-   public socket< endpoint<role,socket,logger> >,
-   boost::noncopyable
+   public socket< endpoint<role,socket,logger> >
 {
 public:
     /// Type of the traits class that stores endpoint related types.

--- a/src/http/parser.hpp
+++ b/src/http/parser.hpp
@@ -55,8 +55,8 @@ class parser {
 public:
     // consumes bytes from the stream and returns true if enough bytes have
     // been read
-    bool consume (std::istream& s) {
-        throw "No Implimented";
+    bool consume (std::istream&) {
+        throw "Not Implemented";
     }
     
     void set_version(const std::string& version) {

--- a/src/messages/control.hpp
+++ b/src/messages/control.hpp
@@ -56,7 +56,7 @@ public:
     }
     
     void process_payload(char *input,uint64_t size) {
-        const size_t new_size = m_payload.size() + size;
+        const size_t new_size = static_cast<size_t>(m_payload.size() + size);
         
         if (new_size > PAYLOAD_SIZE_MAX) {
             throw processor::exception("Message payload was too large.",processor::error::MESSAGE_TOO_BIG);
@@ -64,13 +64,13 @@ public:
         
         if (m_masked) {
             // this retrieves ceiling of size / word size
-            size_t n = (size + sizeof(size_t) - 1) / sizeof(size_t);
+            size_t n = static_cast<size_t>((size + sizeof(size_t) - 1) / sizeof(size_t));
             
             // reinterpret the input as an array of word sized integers
             size_t* data = reinterpret_cast<size_t*>(input);
             
             // unmask working buffer
-            for (int i = 0; i < n; i++) {
+            for (size_t i = 0; i < n; i++) {
                 data[i] ^= m_prepared_key;
             }
             
@@ -79,7 +79,7 @@ public:
         }
                 
         // copy working buffer into
-        m_payload.append(input, size);
+        m_payload.append(input, static_cast<size_t>(size));
     }
     
     void complete() {

--- a/src/messages/data.cpp
+++ b/src/messages/data.cpp
@@ -30,6 +30,10 @@
 #include "../processors/processor.hpp"
 #include "../processors/hybi_header.hpp"
 
+#ifdef max
+	#undef max
+#endif // #ifdef max
+
 using websocketpp::message::data;
 using websocketpp::processor::hybi_util::circshift_prepared_key;
 
@@ -75,7 +79,7 @@ void data::process_payload(char *input, size_t size) {
         size_t* data = reinterpret_cast<size_t*>(input);
         
         // unmask working buffer
-        for (int i = 0; i < n; i++) {
+        for (size_t i = 0; i < n; i++) {
             data[i] ^= m_prepared_key;
         }
         
@@ -184,7 +188,8 @@ void data::mask() {
             
             size_t size = m_payload.size()/sizeof(size_t);
             size_t key = m_masking_key.i;
-            if (sizeof(size_t) == 8) {
+			size_t wordSize = sizeof(size_t);
+            if (wordSize == 8) {
                 key <<= 32;
                 key |= (static_cast<size_t>(m_masking_key.i) & 0x00000000FFFFFFFFLL);
             }
@@ -214,4 +219,3 @@ void data::set_live() {
 size_t data::get_index() const {
     return m_index;
 }
-

--- a/src/processors/hybi.hpp
+++ b/src/processors/hybi.hpp
@@ -36,6 +36,13 @@
 
 #include <boost/algorithm/string.hpp>
 
+#ifdef IGNORE
+	#undef IGNORE
+#endif // #ifdef IGNORE
+
+#ifdef min
+	#undef min
+#endif // #ifdef min
 
 namespace websocketpp {
 namespace processor {
@@ -259,7 +266,7 @@ public:
                         break;
                     case hybi_state::IGNORE:
                         s.ignore(m_payload_left);
-                        m_payload_left -= s.gcount();
+                        m_payload_left -= static_cast<size_t>(s.gcount());
                         
                         if (m_payload_left == 0) {
                             reset();
@@ -318,7 +325,7 @@ public:
         
         m_control_message->reset(m_header.get_opcode(),m_header.get_masking_key());
         
-        m_payload_left = m_header.get_payload_size();
+        m_payload_left = static_cast<size_t>(m_header.get_payload_size());
         
         if (m_payload_left == 0) {
             process_frame();
@@ -349,7 +356,7 @@ public:
             }
         }
         
-        m_payload_left = m_header.get_payload_size();
+        m_payload_left = static_cast<size_t>(m_header.get_payload_size());
         
         if (m_payload_left == 0) {
             process_frame();
@@ -368,7 +375,7 @@ public:
         // and the number of bytes left in the payload.
         
         input.read(m_payload_buffer, std::min(m_payload_left, PAYLOAD_BUFFER_SIZE));
-        num = input.gcount();
+        num = static_cast<size_t>(input.gcount());
                 
         if (input.bad()) {
             throw processor::exception("istream readsome error",
@@ -586,7 +593,7 @@ public:
         
         // set close payload
         if (code != close::status::NO_STATUS) {
-            const uint16_t payload = htons(code);
+            const uint16_t payload = htons(static_cast<u_short>(code));
         
             msg->set_payload(std::string(reinterpret_cast<const char*>(&payload), 2));
             msg->append_payload(reason);

--- a/src/processors/hybi_legacy.hpp
+++ b/src/processors/hybi_legacy.hpp
@@ -35,6 +35,10 @@
 
 #include <cassert>
 
+#ifdef min
+	#undef min
+#endif // #ifdef min
+
 namespace websocketpp {
 namespace processor {
 
@@ -56,7 +60,7 @@ public:
         reset();
     }
     
-    void validate_handshake(const http::parser::request& headers) const {
+    void validate_handshake(const http::parser::request& /*headers*/) const {
         
     }
     
@@ -195,7 +199,7 @@ public:
                 if (m_data_message) {
                     size_t num;
                     
-                    num = input.readsome(m_payload_buffer, PAYLOAD_BUFFER_SIZE);
+                    num = static_cast<size_t>(input.readsome(m_payload_buffer, PAYLOAD_BUFFER_SIZE));
                     
                     if (input.bad()) {
                         throw processor::exception("istream readsome error",
@@ -289,8 +293,8 @@ public:
     }
     
     void prepare_close_frame(message::data_ptr msg,
-                             close::status::value code,
-                             const std::string& reason)
+                             close::status::value /*code*/,
+                             const std::string& /*reason*/)
     {
         assert(msg);
         if (msg->get_prepared()) {
@@ -349,4 +353,5 @@ private:
     
 } // processor
 } // websocketpp
+
 #endif // WEBSOCKET_PROCESSOR_HYBI_LEGACY_HPP

--- a/src/processors/hybi_util.cpp
+++ b/src/processors/hybi_util.cpp
@@ -33,7 +33,8 @@ namespace hybi_util {
 
 size_t prepare_masking_key(const masking_key_type& key) {
     size_t prepared_key = key.i;
-    if (sizeof(size_t) == 8) {
+	size_t wordSize = sizeof(size_t);
+    if (wordSize == 8) {
         prepared_key <<= 32;
         prepared_key |= (static_cast<size_t>(key.i) & 0x00000000FFFFFFFFLL);
     }

--- a/src/processors/processor.hpp
+++ b/src/processors/processor.hpp
@@ -82,7 +82,7 @@ public:
 namespace websocketpp {
 namespace processor {
     
-class processor_base {
+class processor_base : boost::noncopyable {
 public:
     virtual ~processor_base() {}
     // validate client handshake

--- a/src/roles/client.hpp
+++ b/src/roles/client.hpp
@@ -276,7 +276,7 @@ void client<endpoint>::run(bool perpetual) {
     
     // TODO: preliminary support for multi-threaded clients. Finish external
     // interface once better tested
-    int num_threads = 1;
+    size_t num_threads = 1;
     
     if (num_threads == 1) {
         m_io_service.run();

--- a/src/roles/server.hpp
+++ b/src/roles/server.hpp
@@ -63,7 +63,7 @@ class server {
 public:
     // Connection specific details
     template <typename connection_type>
-    class connection {
+    class connection : boost::noncopyable {
     public:
         typedef connection<connection_type> type;
         typedef endpoint endpoint_type;
@@ -443,7 +443,7 @@ void server<endpoint>::connection<connection_type>::async_init() {
 template <class endpoint>
 template <class connection_type>
 void server<endpoint>::connection<connection_type>::handle_read_request(
-    const boost::system::error_code& error, std::size_t bytes_transferred)
+    const boost::system::error_code& error, std::size_t /*bytes_transferred*/)
 {
     if (error) {
         // log error

--- a/src/sockets/plain.hpp
+++ b/src/sockets/plain.hpp
@@ -39,7 +39,7 @@ namespace websocketpp {
 namespace socket {
 
 template <typename endpoint_type>
-class plain {
+class plain : boost::noncopyable {
 public:
     boost::asio::io_service& get_io_service() {
         return m_io_service;

--- a/src/uri.cpp
+++ b/src/uri.cpp
@@ -316,5 +316,5 @@ uint16_t uri::get_port_from_string(const std::string& port) const {
         throw websocketpp::uri_exception("Error parsing port string: "+port);
     }
     
-    return t_port;
+    return static_cast<uint16_t>(t_port);
 }

--- a/src/utf8_validator/utf8_validator.hpp
+++ b/src/utf8_validator/utf8_validator.hpp
@@ -45,7 +45,7 @@ public:
     validator() : m_state(UTF8_ACCEPT),m_codepoint(0) {}
     
     bool consume (uint32_t byte) {
-        if (utf8_validator::decode(&m_state,&m_codepoint,byte) == UTF8_REJECT) {
+        if (utf8_validator::decode(&m_state,&m_codepoint,static_cast<uint8_t>(byte)) == UTF8_REJECT) {
             return false;
         }
         return true;

--- a/src/websocket_frame.hpp
+++ b/src/websocket_frame.hpp
@@ -71,7 +71,7 @@ private:
  */
     
 template <class rng_policy>
-class parser {
+class parser : boost::noncopyable {
 public:
     // basic payload byte flags
     static const uint8_t BPB0_OPCODE = 0x0F;


### PR DESCRIPTION
This fixes some errors caused by Windows defining things like min and max, as well as a number of warnings about type conversion, unused parameters, inability to generate assignment operators, and constant conditions.

All type conversions were assumed to be intentional, and static_casts have been added to remove the compiler warnings.

The server code should now build cleanly with level 4 warnings enabled (as used in my project), and the client code should build cleanly with level 3 warnings enabled (as used by the WebSocket++ projects).

I haven't committed any changes I made to the VS2010 projects, as I wasn't sure if there were generated or not (I also couldn't actually get your example projects to link correctly).
