### PR TITLE
Compiler error due to ambiguous methods resolution

### DIFF
--- a/src/roles/server.hpp
+++ b/src/roles/server.hpp
@@ -296,7 +296,8 @@ void server<endpoint>::listen(const std::string &host, const std::string &servic
     if (endpoint_iterator == end) {
         throw std::invalid_argument("Can't resolve host/service to listen");
     }
-    listen(*endpoint_iterator,n);
+    const boost::asio::ip::tcp::endpoint &ep = *endpoint_iterator;
+    listen(ep,n);
 }
 
 template <class endpoint>


### PR DESCRIPTION
The error of compiler:
websocketpp/roles/server.hpp:299: warning: ISO C++ says that these are ambiguous, even though the worst c
onversion for the first is better than the worst conversion for the second:

Compiler version
gcc (GCC) 4.4.6 20110731 (Red Hat 4.4.6-3)
Copyright (C) 2010 Free Software Foundation, Inc.
