### PR TITLE
Update src/roles/client.hpp

### DIFF
--- a/src/roles/client.hpp
+++ b/src/roles/client.hpp
@@ -207,8 +207,8 @@ public:
        m_io_service(m),
        m_gen(m_rng,
              boost::random::uniform_int_distribution<>(
-                std::numeric_limits<int32_t>::min(),
-                std::numeric_limits<int32_t>::max()
+                (std::numeric_limits<int32_t>::min)(),
+                (std::numeric_limits<int32_t>::max)()
              )) {}
     
     connection_ptr get_connection(const std::string& u);


### PR DESCRIPTION
 sometimes it cause error。
 I have check the function "uniform_int_distribution" ，
 the right way to construct is
 boost::random::uniform_int_distribution<>(
                (std::numeric_limits<int32_t>::min)(),
                (std::numeric_limits<int32_t>::max)()
             )
not 
 boost::random::uniform_int_distribution<>(
                std::numeric_limits<int32_t>::min(),
                std::numeric_limits<int32_t>::max()
             )
maybe sometimes the second way would not cause error,but sometimes it dose.so I modified.
