### PR TITLE
Added missing 'inline' directives

### DIFF
--- a/websocketpp/transport/asio/base.hpp
+++ b/websocketpp/transport/asio/base.hpp
@@ -79,12 +79,12 @@ public:
 	}
 };
 
-const lib::error_category& get_category() {
+inline const lib::error_category& get_category() {
 	static category instance;
 	return instance;
 }
 
-lib::error_code make_error_code(error::value e) {
+inline lib::error_code make_error_code(error::value e) {
 	return lib::error_code(static_cast<int>(e), get_category());
 }
 

--- a/websocketpp/transport/asio/security/base.hpp
+++ b/websocketpp/transport/asio/security/base.hpp
@@ -105,12 +105,12 @@ public:
 	}
 };
 
-const lib::error_category& get_socket_category() {
+inline const lib::error_category& get_socket_category() {
     static socket_category instance;
     return instance;
 }
 
-lib::error_code make_error(error::value e) {
+inline lib::error_code make_error(error::value e) {
 	return lib::error_code(static_cast<int>(e), get_socket_category());
 }
 


### PR DESCRIPTION
As per issue #178 and commit 290b7190487821c9075ecb8b90d75d97ff7e85c1, most inline directives were fixed, but I found a few that were still missing.
