### PR TITLE
missing include file

### DIFF
--- a/src/messages/data.hpp
+++ b/src/messages/data.hpp
@@ -36,6 +36,7 @@
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/function.hpp>
 #include <boost/intrusive_ptr.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/utility.hpp>
 


### PR DESCRIPTION
Make fails on os x 10.7. Fix is src/messages/data.hpp needs boost/thread/locks.hpp.
