### PR TITLE
removed mutex lock to avoid race condition. Doubt the lock serves a purpose

### DIFF
--- a/examples/telemetry_client/telemetry_client.cpp
+++ b/examples/telemetry_client/telemetry_client.cpp
@@ -98,7 +98,12 @@ public:
 
         while(1) {
             {
-                scoped_lock guard(m_lock);
+                // FIXME: Removed the lock line below to avoid race condition.
+                // this is read=only thread, so lock should not be needed. Alternative, is
+                // making sure that the sleep(1) happens before locking the mutex.
+                
+                //scoped_lock guard(m_lock);
+                
                 // If the connection has been closed, stop generating telemetry
                 if (m_done) {break;}
 


### PR DESCRIPTION
Hi Peter,

I hope you are well. Thank you for writing websocketpp. As I was trying to figure it out, it encountered a race condition on my machine with the example code. I am pretty sure that the mutex locks you put into the code are not necessary as I don't see how a concurrency error could occur. The only writes change m_open or m_done to true, independent of the previous value (so no data is lost if both attempt to update simultaneously), and the other tread reads exclusively. Then again, if I am wrong, I would appreciate being enlightened.

Take care,
## Frank.

I don't think the mutex needs to be locked in the telemetry loop, since it is a read-only thread for that data. A race condition can occur since the sleep(1) is within the lock scope and immediately followed by continue and relock.
Since the other threads in writing can only write one value, a lock is likely not needed there either.
