### PR TITLE
Fix memory leak on create

### DIFF
--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -443,8 +443,15 @@ protected:
             m_async_write_handler = lib::bind(&type::handle_async_write,
                 get_shared(), lib::placeholders::_1, lib::placeholders::_2);
         }
-
-        return socket_con_type::init_asio(io_service, m_strand, m_is_server);
+		
+		lib::error_code ec = socket_con_type::init_asio(io_service, m_strand, m_is_server);
+		if (ec) {
+			// reset the handlers to break the circular reference: this->handler->this
+			m_async_read_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
+			m_async_write_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
+		}
+		
+		return ec;
     }
 
     void handle_pre_init(lib::error_code const & ec) {


### PR DESCRIPTION
If the socket fails to initialize, e.g., by omitting the tis init
handler, the connection is leaked, since there is a circular reference
between the connection and its async_read/async_write handlers. To fix
this, check the error code, and reset the handler if an error has
occurred.
