### PR TITLE
Avoid leak when stopping server

### DIFF
--- a/websocketpp/roles/server_endpoint.hpp
+++ b/websocketpp/roles/server_endpoint.hpp
@@ -104,7 +104,13 @@ public:
             endpoint_type::m_elog.write(log::elevel::rerror,
                 "start_accept error: "+ec.message());
         }
-    }
+		
+		if (ec) {
+			// Terminate the connection to prevent memory leaks.
+			lib::error_code con_ec;
+			con->terminate(con_ec);
+		}
+	}
 
     void handle_accept(connection_ptr con, lib::error_code const & ec) {
         if (ec) {


### PR DESCRIPTION
If accept fails, e.g., because the server is no longer listening the
connection object is not terminated and it results in a memory leak:
connection -> handler -> connection.

Note: terminating connections that are not "accepted" results in asio error 10009 (invalid socket), since the OS socket is not created until accept succeeds. While this error appears to be harmless con->terminate() probably needs to be reworked to avoid generating a spurious log warning. 

In addition, during stop, the endpoint goes through the accept loop one time too many: stop_listening() results in the current accept to fail with operation_cancelled, but then handle_accept calls accept_async unconditionally. In this case the call to accept_async is not necessary.

Thanks,
--aydan 
