### PR TITLE
Use _WIN32 instead of WIN32 preprocessor directive

### DIFF
--- a/websocketpp/common/network.hpp
+++ b/websocketpp/common/network.hpp
@@ -29,7 +29,7 @@
 #define WEBSOCKETPP_COMMON_NETWORK_HPP
 
 // For ntohs and htons
-#if defined(WIN32)
+#if defined(_WIN32)
     #include <winsock2.h>
 #else
     //#include <arpa/inet.h>

--- a/websocketpp/common/platforms.hpp
+++ b/websocketpp/common/platforms.hpp
@@ -33,7 +33,7 @@
  * don't fit somewhere else better.
  */
 
-#if defined(WIN32) && !defined(NOMINMAX)
+#if defined(_WIN32) && !defined(NOMINMAX)
     // don't define min and max macros that conflict with std::min and std::max
     #define NOMINMAX
 #endif

--- a/websocketpp/common/stdint.hpp
+++ b/websocketpp/common/stdint.hpp
@@ -32,7 +32,7 @@
     #define __STDC_LIMIT_MACROS 1
 #endif
 
-#if WIN32 && (_MSC_VER < 1600)
+#if defined (_WIN32) && defined (_MSC_VER) && (_MSC_VER < 1600)
     #include <boost/cstdint.hpp>
 
     using boost::int8_t;


### PR DESCRIPTION
Hey,

MinGW only defines _WIN32 whereas MSVC defines both. Using _WIN32 is cleaner because it's not allowed to be defined by the user/programmer, but must come from the compiler.

The `defined` checks get rid of `warning: "_WIN32" is not defined` on other platforms.

Regards,
Dominik
