### PR TITLE
Prevent msvc assertion from firing

### DIFF
--- a/websocketpp/http/impl/request.hpp
+++ b/websocketpp/http/impl/request.hpp
@@ -127,7 +127,8 @@ inline size_t request::consume(const char *buf, size_t len) {
             }
         }
 
-        begin = end+sizeof(header_delimiter)-1;
+        const auto validCheckedIteratorsOffset = sizeof(header_delimiter)-1;
+        begin = end+validCheckedIteratorsOffset;
     }
 }
 


### PR DESCRIPTION
Microsoft's Checked iterators fire an assertion when they detect going
out of bound. The iterator position formula

```
   begin = end+sizeof(header_delimiter)-1;
```

Can evaluate `end+sizeof(header_delimiter)` first, which can go one
past the maximum iterator position.

Evaluating `sizeof(header_delimiter)-1` first prevents this.
