### PR TITLE
fix compiler warnings for clang/c++11

### DIFF
--- a/websocketpp/base64/base64.hpp
+++ b/websocketpp/base64/base64.hpp
@@ -103,7 +103,7 @@ inline std::string base64_encode(unsigned char const * bytes_to_encode, unsigned
 }
 
 inline std::string base64_encode(std::string const & data) {
-    return base64_encode(reinterpret_cast<const unsigned char *>(data.data()),data.size());
+    return base64_encode(reinterpret_cast<const unsigned char *>(data.data()),(uint)data.size());
 }
 
 inline std::string base64_decode(std::string const & encoded_string) {

--- a/websocketpp/common/network.hpp
+++ b/websocketpp/common/network.hpp
@@ -50,7 +50,7 @@ inline bool is_little_endian() {
 #define TYP_SMLE 1
 #define TYP_BIGE 2
 
-inline uint64_t htonll(uint64_t src) {
+inline uint64_t websocketpp_htonll(uint64_t src) {
     static int typ = TYP_INIT;
     unsigned char c;
     union {
@@ -71,8 +71,8 @@ inline uint64_t htonll(uint64_t src) {
     return x.ull;
 }
 
-inline uint64_t ntohll(uint64_t src) {
-    return htonll(src);
+inline uint64_t websocketpp_ntohll(uint64_t src) {
+    return websocketpp_htonll(src);
 }
 
 } // net

--- a/websocketpp/frame.hpp
+++ b/websocketpp/frame.hpp
@@ -266,7 +266,7 @@ private:
         }
 
         uint64_converter temp64;
-        temp64.i = lib::net::htonll(payload_size);
+        temp64.i = lib::net::websocketpp_htonll(payload_size);
         std::copy(temp64.c+payload_offset,temp64.c+8,bytes);
 
         return 8-payload_offset;
@@ -583,7 +583,7 @@ inline uint16_t get_extended_size(const extended_header &e) {
 inline uint64_t get_jumbo_size(const extended_header &e) {
     uint64_converter temp64;
     std::copy(e.bytes,e.bytes+8,temp64.c);
-    return lib::net::ntohll(temp64.i);
+    return lib::net::websocketpp_ntohll(temp64.i);
 }
 
 /// Extract the full payload size field from a WebSocket header

--- a/websocketpp/processors/hybi13.hpp
+++ b/websocketpp/processors/hybi13.hpp
@@ -630,7 +630,7 @@ protected:
         key.append(constants::handshake_guid);
 
         unsigned char message_digest[20];
-        sha1::calc(key.c_str(),key.length(),message_digest);
+        sha1::calc(key.c_str(),(int)key.length(),message_digest);
         key = base64_encode(message_digest,20);
 
         return lib::error_code();


### PR DESCRIPTION
+ cast numbers to correct type
+ prefix ntohll/htonll to websocketpp_ntohll due to builtin function