### PR TITLE
Recommend do not override CMAKE_INSTALL_PREFIX on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,14 +50,6 @@ set (WEBSOCKETPP_BUILD_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 set (WEBSOCKETPP_BIN ${WEBSOCKETPP_BUILD_ROOT}/bin)
 set (WEBSOCKETPP_LIB ${WEBSOCKETPP_BUILD_ROOT}/lib)
 
-# CMake install step prefix. I assume linux users want the prefix to
-# be the default /usr or /usr/local so this is only adjusted on Windows.
-# - Windows: Build the INSTALL project in your solution file.
-# - Linux/OSX: make install.
-if (MSVC)
-    set (CMAKE_INSTALL_PREFIX "${WEBSOCKETPP_ROOT}/install")
-endif ()
-
 ############  Build customization
 
 # Override from command line "CMake -D<OPTION>=TRUE/FALSE/0/1/ON/OFF"


### PR DESCRIPTION
I'm a Windows user, I don't actually want this--I can set CMAKE_INSTALL_PREFIX myself if necessary.  When I install websocketpp, I intend for the installation to be to a place that's similar in sense to what it is on Unix systems, which on Windows is generally Program Files.  By allowing the CMAKE_INSTALL_PREFIX path to simply default, not only does this default behavior automatically appear, but it also corrects a problem currently existing with the INSTALL project which causes the websocketpp-config.cmake installed by the INSTALL project to contain invalid entries.
