### PR TITLE
CMake configure_file should place config.cmake in the root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,12 +226,12 @@ print_used_build_config()
 
 export (PACKAGE websocketpp)
 
-configure_file (websocketpp-config.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/websocketpp-config.cmake" @ONLY)
-configure_file (websocketpp-configVersion.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/websocketpp-configVersion.cmake" @ONLY)
+configure_file (websocketpp-config.cmake.in websocketpp-config.cmake @ONLY)
+configure_file (websocketpp-configVersion.cmake.in websocketpp-configVersion.cmake @ONLY)
 
 # Install the websocketpp-config.cmake and websocketpp-configVersion.cmake
 install (FILES
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/websocketpp-config.cmake"
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/websocketpp-configVersion.cmake"
+  "websocketpp-config.cmake"
+  "websocketpp-configVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
 


### PR DESCRIPTION
This change allows the configuration of websocketpp-config.cmake to be compliant with what cmake expects when an "export" statement is used.  This adjustment allows the "find_package(websocketpp)" command to behave as expected if a user installs websocketpp via the "INSTALL" project on Windows.