### PR TITLE
 Fix build failure if CMAKE_CXX_FLAGS is not empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
         set (WEBSOCKETPP_PLATFORM_LIBS pthread rt)
         set (WEBSOCKETPP_PLATFORM_TSL_LIBS ssl crypto)
         set (WEBSOCKETPP_BOOST_LIBS system thread)
-        set (CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++0x")
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
         if (NOT APPLE)
             add_definitions (-DNDEBUG -Wall -Wcast-align) # todo: should we use CMAKE_C_FLAGS for these?
         endif ()


### PR DESCRIPTION
The wrong " were adding a new parameter, leading to an expanded flag list like
"-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 ;-std=c++0x"
and an obvious
"g++-4.8.real: fatal error: no input files"
error message.
