### PR TITLE
Using std/boost make_shared for creating shared pointers

### DIFF
--- a/examples/debug_client/debug_client.cpp
+++ b/examples/debug_client/debug_client.cpp
@@ -92,7 +92,7 @@ public:
 
     context_ptr on_tls_init(websocketpp::connection_hdl) {
         m_tls_init = std::chrono::high_resolution_clock::now();
-        context_ptr ctx(new boost::asio::ssl::context(boost::asio::ssl::context::tlsv1));
+        context_ptr ctx = websocketpp::lib::make_shared<boost::asio::ssl::context>(boost::asio::ssl::context::tlsv1);
 
         try {
             ctx->set_options(boost::asio::ssl::context::default_workarounds |

--- a/examples/dev/main.cpp
+++ b/examples/dev/main.cpp
@@ -68,7 +68,7 @@ int main() {
     typedef websocketpp::message_buffer::alloc::con_msg_manager<message_type>
         con_msg_man_type;
 
-    con_msg_man_type::ptr manager(new con_msg_man_type());
+    con_msg_man_type::ptr manager = websocketpp::lib::make_shared<con_msg_man_type>();
 
     size_t foo = 1024;
 

--- a/examples/echo_server_tls/echo_server_tls.cpp
+++ b/examples/echo_server_tls/echo_server_tls.cpp
@@ -33,7 +33,7 @@ std::string get_password() {
 
 context_ptr on_tls_init(websocketpp::connection_hdl hdl) {
     std::cout << "on_tls_init called with hdl: " << hdl.lock().get() << std::endl;
-    context_ptr ctx(new boost::asio::ssl::context(boost::asio::ssl::context::tlsv1));
+    context_ptr ctx = websocketpp::lib::make_shared<boost::asio::ssl::context>(boost::asio::ssl::context::tlsv1);
 
     try {
         ctx->set_options(boost::asio::ssl::context::default_workarounds |

--- a/examples/testee_server/testee_server.cpp
+++ b/examples/testee_server/testee_server.cpp
@@ -124,7 +124,7 @@ int main(int argc, char * argv[]) {
             typedef websocketpp::lib::shared_ptr<websocketpp::lib::thread> thread_ptr;
             std::vector<thread_ptr> ts;
             for (size_t i = 0; i < num_threads; i++) {
-                ts.push_back(thread_ptr(new websocketpp::lib::thread(&server::run, &testee_server)));
+                ts.push_back(websocketpp::lib::make_shared<websocketpp::lib::thread>(&server::run, &testee_server));
             }
 
             for (size_t i = 0; i < num_threads; i++) {

--- a/examples/utility_client/utility_client.cpp
+++ b/examples/utility_client/utility_client.cpp
@@ -119,7 +119,7 @@ public:
         m_endpoint.init_asio();
         m_endpoint.start_perpetual();
 
-        m_thread.reset(new websocketpp::lib::thread(&client::run, &m_endpoint));
+        m_thread = websocketpp::lib::make_shared<websocketpp::lib::thread>(&client::run, &m_endpoint);
     }
 
     ~websocket_endpoint() {
@@ -155,7 +155,7 @@ public:
         }
 
         int new_id = m_next_id++;
-        connection_metadata::ptr metadata_ptr(new connection_metadata(new_id, con->get_handle(), uri));
+        connection_metadata::ptr metadata_ptr = websocketpp::lib::make_shared<connection_metadata>(new_id, con->get_handle(), uri);
         m_connection_list[new_id] = metadata_ptr;
 
         con->set_open_handler(websocketpp::lib::bind(

--- a/tutorials/utility_client/step3.cpp
+++ b/tutorials/utility_client/step3.cpp
@@ -48,7 +48,7 @@ public:
         m_endpoint.init_asio();
         m_endpoint.start_perpetual();
 
-        m_thread.reset(new websocketpp::lib::thread(&client::run, &m_endpoint));
+        m_thread = websocketpp::lib::make_shared<websocketpp::lib::thread>(&client::run, &m_endpoint);
     }
 private:
     client m_endpoint;

--- a/tutorials/utility_client/step4.cpp
+++ b/tutorials/utility_client/step4.cpp
@@ -97,7 +97,7 @@ public:
         m_endpoint.init_asio();
         m_endpoint.start_perpetual();
 
-        m_thread.reset(new websocketpp::lib::thread(&client::run, &m_endpoint));
+        m_thread = websocketpp::lib::make_shared<websocketpp::lib::thread>(&client::run, &m_endpoint);
     }
 
     int connect(std::string const & uri) {
@@ -111,7 +111,7 @@ public:
         }
 
         int new_id = m_next_id++;
-        connection_metadata::ptr metadata_ptr(new connection_metadata(new_id, con->get_handle(), uri));
+        connection_metadata::ptr metadata_ptr = websocketpp::lib::make_shared<connection_metadata>(new_id, con->get_handle(), uri);
         m_connection_list[new_id] = metadata_ptr;
 
         con->set_open_handler(websocketpp::lib::bind(

--- a/tutorials/utility_client/step5.cpp
+++ b/tutorials/utility_client/step5.cpp
@@ -119,7 +119,7 @@ public:
         m_endpoint.init_asio();
         m_endpoint.start_perpetual();
 
-        m_thread.reset(new websocketpp::lib::thread(&client::run, &m_endpoint));
+        m_thread = websocketpp::lib::make_shared<websocketpp::lib::thread>(&client::run, &m_endpoint);
     }
 
     ~websocket_endpoint() {
@@ -155,7 +155,7 @@ public:
         }
 
         int new_id = m_next_id++;
-        connection_metadata::ptr metadata_ptr(new connection_metadata(new_id, con->get_handle(), uri));
+        connection_metadata::ptr metadata_ptr = websocketpp::lib::make_shared<connection_metadata>(new_id, con->get_handle(), uri);
         m_connection_list[new_id] = metadata_ptr;
 
         con->set_open_handler(websocketpp::lib::bind(

--- a/websocketpp/common/functional.hpp
+++ b/websocketpp/common/functional.hpp
@@ -49,6 +49,7 @@ namespace lib {
     using std::bind;
     using std::ref;
     namespace placeholders = std::placeholders;
+    #define _WEBSOCKETPP_NULL_FUNCTION_ nullptr
 #else
     using boost::function;
     using boost::bind;
@@ -58,6 +59,7 @@ namespace lib {
         using ::_1;
         using ::_2;
     }
+    #define _WEBSOCKETPP_NULL_FUNCTION_ 0
 #endif
 
 } // namespace lib

--- a/websocketpp/common/memory.hpp
+++ b/websocketpp/common/memory.hpp
@@ -38,6 +38,7 @@
     #include <memory>
 #else
     #include <boost/shared_ptr.hpp>
+	#include <boost/make_shared.hpp>
     #include <boost/scoped_array.hpp>
     #include <boost/enable_shared_from_this.hpp>
     #include <boost/pointer_cast.hpp>
@@ -51,6 +52,7 @@ namespace lib {
     using std::weak_ptr;
     using std::enable_shared_from_this;
     using std::static_pointer_cast;
+    using std::make_shared;
 
     typedef std::unique_ptr<unsigned char[]> unique_ptr_uchar_array;
 #else
@@ -58,6 +60,7 @@ namespace lib {
     using boost::weak_ptr;
     using boost::enable_shared_from_this;
     using boost::static_pointer_cast;
+    using boost::make_shared;
 
     typedef boost::scoped_array<unsigned char> unique_ptr_uchar_array;
 #endif

--- a/websocketpp/http/request.hpp
+++ b/websocketpp/http/request.hpp
@@ -51,7 +51,7 @@ public:
     typedef lib::shared_ptr<type> ptr;
 
     request()
-      : m_buf(new std::string())
+      : m_buf(lib::make_shared<std::string>())
       , m_ready(false) {}
 
     /// DEPRECATED parse a complete header (\r\n\r\n MUST be in the istream)

--- a/websocketpp/http/response.hpp
+++ b/websocketpp/http/response.hpp
@@ -58,7 +58,7 @@ public:
 
     response()
       : m_read(0)
-      , m_buf(new std::string())
+      , m_buf(lib::make_shared<std::string>())
       , m_status_code(status_code::uninitialized)
       , m_state(RESPONSE_LINE) {}
 

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -1969,35 +1969,35 @@ connection<config>::get_processor(int version) const {
     
     switch (version) {
         case 0:
-            p.reset(new processor::hybi00<config>(
+            p = lib::make_shared<processor::hybi00<config> >(
                 transport_con_type::is_secure(),
                 m_is_server,
                 m_msg_manager
-            ));
+            );
             break;
         case 7:
-            p.reset(new processor::hybi07<config>(
+            p = lib::make_shared<processor::hybi07<config> >(
                 transport_con_type::is_secure(),
                 m_is_server,
                 m_msg_manager,
                 m_rng
-            ));
+            );
             break;
         case 8:
-            p.reset(new processor::hybi08<config>(
+            p = lib::make_shared<processor::hybi08<config> >(
                 transport_con_type::is_secure(),
                 m_is_server,
                 m_msg_manager,
                 m_rng
-            ));
+            );
             break;
         case 13:
-            p.reset(new processor::hybi13<config>(
+            p = lib::make_shared<processor::hybi13<config> >(
                 transport_con_type::is_secure(),
                 m_is_server,
                 m_msg_manager,
                 m_rng
-            ));
+            );
             break;
         default:
             return p;

--- a/websocketpp/impl/endpoint_impl.hpp
+++ b/websocketpp/impl/endpoint_impl.hpp
@@ -42,8 +42,8 @@ endpoint<connection,config>::create_connection() {
 
     //scoped_lock_type guard(m_mutex);
     // Create a connection on the heap and manage it using a shared pointer
-    connection_ptr con(new connection_type(m_is_server,m_user_agent,m_alog,
-        m_elog, m_rng));
+    connection_ptr con = lib::make_shared<connection_type>(m_is_server,m_user_agent,m_alog,
+        m_elog, m_rng);
 
     connection_weak_ptr w(con);
 

--- a/websocketpp/message_buffer/alloc.hpp
+++ b/websocketpp/message_buffer/alloc.hpp
@@ -53,7 +53,7 @@ public:
      * @return A shared pointer to an empty new message
      */
     message_ptr get_message() {
-        return message_ptr(new message(type::shared_from_this()));
+        return message_ptr(lib::make_shared<message>(type::shared_from_this()));
     }
 
     /// Get a message buffer with specified size and opcode
@@ -64,7 +64,7 @@ public:
      * @return A shared pointer to a new message with specified size.
      */
     message_ptr get_message(frame::opcode::value op,size_t size) {
-        return message_ptr(new message(type::shared_from_this(),op,size));
+        return message_ptr(lib::make_shared<message>(type::shared_from_this(),op,size));
     }
 
     /// Recycle a message
@@ -94,7 +94,7 @@ public:
      * @return A pointer to the requested connection message manager.
      */
     con_msg_man_ptr get_manager() const {
-        return con_msg_man_ptr(new con_msg_manager());
+        return con_msg_man_ptr(lib::make_shared<con_msg_manager>());
     }
 };
 

--- a/websocketpp/message_buffer/pool.hpp
+++ b/websocketpp/message_buffer/pool.hpp
@@ -171,7 +171,7 @@ public:
      * @return A shared pointer to a new message with specified size.
      */
     message_ptr get_message(size_t size) const {
-        return message_ptr(new message(size));
+        return lib::make_shared<message>(size);
     }
 
     /// Recycle a message
@@ -201,7 +201,7 @@ public:
      * @return A pointer to the requested connection message manager.
      */
     con_msg_man_ptr get_manager() const {
-        return con_msg_man_ptr(new con_msg_manager());
+        return lib::make_shared<con_msg_manager>();
     }
 };
 

--- a/websocketpp/processors/hybi00.hpp
+++ b/websocketpp/processors/hybi00.hpp
@@ -209,12 +209,12 @@ public:
         if (last_colon == std::string::npos ||
             (last_sbrace != std::string::npos && last_sbrace > last_colon))
         {
-            return uri_ptr(new uri(base::m_secure, h, request.get_uri()));
+            return lib::make_shared<uri>(base::m_secure, h, request.get_uri());
         } else {
-            return uri_ptr(new uri(base::m_secure,
+            return lib::make_shared<uri>(base::m_secure,
                                    h.substr(0,last_colon),
                                    h.substr(last_colon+1),
-                                   request.get_uri()));
+                                   request.get_uri());
         }
 
         // TODO: check if get_uri is a full uri

--- a/websocketpp/processors/processor.hpp
+++ b/websocketpp/processors/processor.hpp
@@ -140,12 +140,12 @@ uri_ptr get_uri_from_host(request_type & request, std::string scheme) {
     if (last_colon == std::string::npos ||
         (last_sbrace != std::string::npos && last_sbrace > last_colon))
     {
-        return uri_ptr(new uri(scheme, h, request.get_uri()));
+        return lib::make_shared<uri>(scheme, h, request.get_uri());
     } else {
-        return uri_ptr(new uri(scheme,
+        return lib::make_shared<uri>(scheme,
                                h.substr(0,last_colon),
                                h.substr(last_colon+1),
-                               request.get_uri()));
+                               request.get_uri());
     }
 }
 

--- a/websocketpp/roles/client_endpoint.hpp
+++ b/websocketpp/roles/client_endpoint.hpp
@@ -112,7 +112,7 @@ public:
      * @return A connection_ptr to the new connection
      */
     connection_ptr get_connection(std::string const & u, lib::error_code & ec) {
-        uri_ptr location(new uri(u));
+        uri_ptr location = lib::make_shared<uri>(u);
 
         if (!location->get_valid()) {
             ec = error::make_error_code(error::invalid_uri);

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -169,7 +169,7 @@ public:
         // TODO: return errors for illegal URIs here?
         // TODO: should https urls be illegal for the moment?
         m_proxy = uri;
-        m_proxy_data.reset(new proxy_data());
+        m_proxy_data = lib::make_shared<proxy_data>();
         ec = lib::error_code();
     }
 
@@ -290,11 +290,9 @@ public:
      * needed.
      */
     timer_ptr set_timer(long duration, timer_handler callback) {
-        timer_ptr new_timer(
-            new boost::asio::deadline_timer(
-                *m_io_service,
-                boost::posix_time::milliseconds(duration)
-            )
+        timer_ptr new_timer = lib::make_shared<boost::asio::deadline_timer>(
+            *m_io_service,
+            boost::posix_time::milliseconds(duration)
         );
 
         if (config::enable_multithreading) {
@@ -419,7 +417,7 @@ protected:
         m_io_service = io_service;
 
         if (config::enable_multithreading) {
-            m_strand.reset(new boost::asio::strand(*io_service));
+            m_strand = lib::make_shared<boost::asio::strand>(*io_service);
 
             m_async_read_handler = m_strand->wrap(lib::bind(
                 &type::handle_async_read, get_shared(),lib::placeholders::_1,
@@ -442,8 +440,8 @@ protected:
         if (ec) {
             // reset the handlers to break the circular reference:
             // this->handler->this
-            m_async_read_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
-            m_async_write_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
+            m_async_read_handler = _WEBSOCKETPP_NULL_FUNCTION_;
+            m_async_write_handler = _WEBSOCKETPP_NULL_FUNCTION_;
         }
 
         return ec;
@@ -869,7 +867,7 @@ protected:
         if (m_read_handler) {
             m_read_handler(tec,bytes_transferred);
             // TODO: why does this line break things?
-            //m_read_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
+            //m_read_handler = _WEBSOCKETPP_NULL_FUNCTION_;
         } else {
             // This can happen in cases where the connection is terminated while
             // the transport is waiting on a read.
@@ -940,7 +938,7 @@ protected:
         if (m_write_handler) {
             m_write_handler(tec);
             // TODO: why does this line break things?
-            //m_write_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
+            //m_write_handler = _WEBSOCKETPP_NULL_FUNCTION_;
         } else {
             // This can happen in cases where the connection is terminated while
             // the transport is waiting on a read.
@@ -996,12 +994,12 @@ protected:
         // Reset cached handlers now that we won't be reading or writing anymore
         // These cached handlers store shared pointers to this connection and
         // will leak the connection if not destroyed.
-        m_async_read_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
-        m_async_write_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
-        m_init_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
+        m_async_read_handler = _WEBSOCKETPP_NULL_FUNCTION_;
+        m_async_write_handler = _WEBSOCKETPP_NULL_FUNCTION_;
+        m_init_handler = _WEBSOCKETPP_NULL_FUNCTION_;
 
-        m_read_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
-        m_write_handler = _WEBSOCKETPP_NULLPTR_TOKEN_;
+        m_read_handler = _WEBSOCKETPP_NULL_FUNCTION_;
+        m_write_handler = _WEBSOCKETPP_NULL_FUNCTION_;
 
         timer_ptr shutdown_timer;
         shutdown_timer = set_timer(

--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -176,7 +176,7 @@ public:
 
         m_io_service = ptr;
         m_external_io_service = true;
-        m_acceptor.reset(new boost::asio::ip::tcp::acceptor(*m_io_service));
+        m_acceptor = lib::make_shared<boost::asio::ip::tcp::acceptor>(*m_io_service);
         m_state = READY;
         ec = lib::error_code();
     }
@@ -205,7 +205,7 @@ public:
      * @param ec Set to indicate what error occurred, if any.
      */
     void init_asio(lib::error_code & ec) {
-        init_asio(new boost::asio::io_service(),ec);
+        init_asio(new boost::asio::io_service(), ec);
         m_external_io_service = false;
     }
 
@@ -597,7 +597,7 @@ public:
      * @since 0.3.0
      */
     void start_perpetual() {
-        m_work.reset(new boost::asio::io_service::work(*m_io_service));
+        m_work = lib::make_shared<boost::asio::io_service::work>(*m_io_service);
     }
 
     /// Clears the endpoint's perpetual flag, allowing it to exit when empty
@@ -625,11 +625,9 @@ public:
      * needed.
      */
     timer_ptr set_timer(long duration, timer_handler callback) {
-        timer_ptr new_timer(
-            new boost::asio::deadline_timer(
-                *m_io_service,
-                boost::posix_time::milliseconds(duration)
-            )
+        timer_ptr new_timer = lib::make_shared<boost::asio::deadline_timer>(
+            *m_io_service,
+            boost::posix_time::milliseconds(duration)
         );
 
         new_timer->async_wait(
@@ -763,7 +761,7 @@ protected:
 
         // Create a resolver
         if (!m_resolver) {
-            m_resolver.reset(new boost::asio::ip::tcp::resolver(*m_io_service));
+            m_resolver = lib::make_shared<boost::asio::ip::tcp::resolver>(*m_io_service);
         }
 
         std::string proxy = tcon->get_proxy();
@@ -776,7 +774,7 @@ protected:
         } else {
             lib::error_code ec;
 
-            uri_ptr pu(new uri(proxy));
+            uri_ptr pu = lib::make_shared<uri>(proxy);
 
             if (!pu->get_valid()) {
                 cb(make_error_code(error::proxy_invalid));

--- a/websocketpp/transport/asio/security/none.hpp
+++ b/websocketpp/transport/asio/security/none.hpp
@@ -164,7 +164,7 @@ protected:
             return socket::make_error_code(socket::error::invalid_state);
         }
 
-        m_socket.reset(new boost::asio::ip::tcp::socket(*service));
+        m_socket = lib::make_shared<boost::asio::ip::tcp::socket>(*service);
 
         m_state = READY;
 

--- a/websocketpp/transport/asio/security/tls.hpp
+++ b/websocketpp/transport/asio/security/tls.hpp
@@ -193,7 +193,7 @@ protected:
         if (!m_context) {
             return socket::make_error_code(socket::error::invalid_tls_context);
         }
-        m_socket.reset(new socket_type(*service,*m_context));
+        m_socket = lib::make_shared<socket_type>(*service,*m_context);
 
         m_io_service = service;
         m_strand = strand;


### PR DESCRIPTION
Using make_shared for creating boost/std shared pointers will reduce the number of allocations
I also fixed boost::function nulling issue
