### PR TITLE
fixed 'localtime_*' compilation error MinGW

### DIFF
--- a/websocketpp/common/time.hpp
+++ b/websocketpp/common/time.hpp
@@ -40,7 +40,9 @@ namespace lib {
 /// Thread safe cross platform localtime
 inline std::tm localtime(std::time_t const & time) {
     std::tm tm_snapshot;
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+#if (defined(__MINGW32__) || defined(__MINGW64__))
+    memcpy(&tm_snapshot, ::localtime(&time), sizeof(std::tm));
+#elif (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
     localtime_s(&tm_snapshot, &time); 
 #else
     localtime_r(&time, &tm_snapshot); // POSIX  


### PR DESCRIPTION
I got the following compilation error when compiling a project including websocketpp with MinGW:

====================================================================================
[ 95%] Building CXX object CMakeFiles/Sources/MyProject/CMakeFiles/MyProject.dir/TestClient.cpp.obj
In file included from F:/Project/MyProject/build/cmake/../../extlibs/include/websocketpp/logger/basic.hpp:49:0,
from F:/Project/MyProject/build/cmake/../../extlibs/include/websocketpp/config/core.hpp:51,
from F:/Project/MyProject/build/cmake/../../extlibs/include/websocketpp/config/asio_no_tls.hpp:31,
from F:\Project\MyProject\Sources\MyProject\WebSocketClient.hpp:8,
from F:\Project\MyProject\Sources\MyProject\TestClient.hpp:34,
from F:\Project\MyProject\Sources\MyProject\TestClient.cpp:2:
F:/Project/MyProject/build/cmake/../../extlibs/include/websocketpp/common/time.hpp: In function 'tm websocketpp::lib::localtime(const time_t&)':
F:/Project/MyProject/build/cmake/../../extlibs/include/websocketpp/common/time.hpp:44:36: error: 'localtime_s' was not declared in this scope
localtime_s(&tm_snapshot, &time);
^
compilation terminated due to -Wfatal-errors.
CMakeFiles\Sources\MyProject\CMakeFiles\MyProject.dir\build.make:57: recipe for target 'CMakeFiles/Sources/MyProject/CMakeFiles/MyProject.dir/TestClient.cpp.obj' failed
make[3]: *** [CMakeFiles/Sources/MyProject/CMakeFiles/MyProject.dir/TestClient.cpp.obj] Error 1
CMakeFiles\Makefile2:1063: recipe for target 'CMakeFiles/Sources/MyProject/CMakeFiles/MyProject.dir/all' failed
make[2]: *** [CMakeFiles/Sources/MyProject/CMakeFiles/MyProject.dir/all] Error 2
CMakeFiles\Makefile2:1075: recipe for target 'CMakeFiles/Sources/MyProject/CMakeFiles/MyProject.dir/rule' failed
make[1]: *** [CMakeFiles/Sources/MyProject/CMakeFiles/MyProject.dir/rule] Error 2

Makefile:329: recipe for target 'MyProject' failed
make: *** [MyProject] Error 2

====================================================================================

Note
============

MinGW does not define neither localtime_s nor locatime_r.

Discussion here: http://stackoverflow.com/questions/18551409/localtime-r-support-on-mingw
MinGW Note here: http://sourceforge.net/p/mingw-w64/mailman/message/21523522/