### PR TITLE
Fix deadline_timer creation with no C++0X support

### DIFF
--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -639,10 +639,7 @@ public:
      * needed.
      */
     timer_ptr set_timer(long duration, timer_handler callback) {
-        timer_ptr new_timer = lib::make_shared<boost::asio::deadline_timer>(
-            *m_io_service,
-            boost::posix_time::milliseconds(duration)
-        );
+        timer_ptr new_timer(new boost::asio::deadline_timer(*m_io_service, boost::posix_time::milliseconds(duration)));
 
         new_timer->async_wait(
             lib::bind(


### PR DESCRIPTION
On gcc version 4.8.1 no C++0X support I get error on timer creation:
...
/usr/include/boost/asio/basic_deadline_timer.hpp:178:3: note:   no known conversion for argument 1 from ‘const boost::asio::io_service’ to ‘boost::asio::io_service&’
...
As I see it happened because of make_shared signature:
 template<typename T, typename Arg1, typename Arg2 >
    shared_ptr<T> make_shared( Arg1 const & arg1, Arg2 const & arg2 );
Source code example:
typedef websocketpp::server<some_config>::timer_ptr timer_ptr;
m_timer = m_server.set_timer(1000, bind(&session_impl::on_tick, this, ::_1));