### PR TITLE
Make transport::asio::connection::get_strand() public.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -33,7 +33,7 @@ PROJECT_NAME           = "websocketpp"
 # if some version control system is used.
 
 
-PROJECT_NUMBER         = "0.5.0"
+PROJECT_NUMBER         = "0.5.x-dev"
 
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 HEAD
-- BREAKING TRANSPORT POLICY CHANGE: Custom transport policies will now be 
+- BREAKING TRANSPORT POLICY CHANGE: Custom transport policies will now be
   required to include a new method `void set_uri(uri_ptr u)`. An implementation
   is not required. The stub transport policy includes an example stub method
   that can be pasted into any existing custom transport policy to fulfill this
@@ -7,10 +7,12 @@ HEAD
   configs.
 - BREAKING SOCKET POLICY CHANGE: Custom asio transport socket policies will now
   be required to include a new method `void set_uri(uri_ptr u)`. Like with the
-  transport layer, an implementation is not required. This does not affect 
+  transport layer, an implementation is not required. This does not affect
   anyone using the bundled socket policies.
 - Improvement: Outgoing TLS connections to servers using the SNI extension to
   choose a certificate will now work.
+- Feature: Adds a vectored/scatter-gather write handler to the iostream
+  transport.
 
 0.5.0 - 2015-01-22
 - BREAKING UTILITY CHANGE: Deprecated methods `http::parser::parse_headers`,

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,16 @@
 HEAD
+- BREAKING TRANSPORT POLICY CHANGE: Custom transport policies will now be 
+  required to include a new method `void set_uri(uri_ptr u)`. An implementation
+  is not required. The stub transport policy includes an example stub method
+  that can be pasted into any existing custom transport policy to fulfill this
+  requirement. This does not affect anyone using the bundled transports or
+  configs.
+- BREAKING SOCKET POLICY CHANGE: Custom asio transport socket policies will now
+  be required to include a new method `void set_uri(uri_ptr u)`. Like with the
+  transport layer, an implementation is not required. This does not affect 
+  anyone using the bundled socket policies.
+- Improvement: Outgoing TLS connections to servers using the SNI extension to
+  choose a certificate will now work.
 
 0.5.0 - 2015-01-22
 - BREAKING UTILITY CHANGE: Deprecated methods `http::parser::parse_headers`,

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-WebSocket++ (0.5.0)
+WebSocket++ (0.5.x-dev)
 ==========================
 
 WebSocket++ is a header only C++ library that implements RFC6455 The WebSocket

--- a/test/endpoint/endpoint.cpp
+++ b/test/endpoint/endpoint.cpp
@@ -57,6 +57,33 @@ BOOST_AUTO_TEST_CASE( initialize_server_asio_external ) {
     s.init_asio(&ios);
 }
 
+#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+BOOST_AUTO_TEST_CASE( move_construct_server_core ) {
+    websocketpp::server<websocketpp::config::core> s1;
+    
+    websocketpp::server<websocketpp::config::core> s2(std::move(s1));
+}
+
+BOOST_AUTO_TEST_CASE( emplace ) {
+    std::stringstream out1;
+    std::stringstream out2;
+    
+    std::vector<websocketpp::server<websocketpp::config::asio_tls>> v;
+    
+    v.emplace_back();
+    v.emplace_back();
+    
+    v[0].get_alog().set_ostream(&out1);
+    v[0].get_alog().set_ostream(&out2);
+    
+    v[0].get_alog().write(websocketpp::log::alevel::app,"devel0");
+    v[1].get_alog().write(websocketpp::log::alevel::app,"devel1");
+    BOOST_CHECK( out1.str().size() > 0 );
+    BOOST_CHECK( out2.str().size() > 0 );
+}
+
+#endif // _WEBSOCKETPP_MOVE_SEMANTICS_
+
 struct endpoint_extension {
     endpoint_extension() : extension_value(5) {}
 

--- a/test/endpoint/endpoint.cpp
+++ b/test/endpoint/endpoint.cpp
@@ -64,6 +64,8 @@ BOOST_AUTO_TEST_CASE( move_construct_server_core ) {
     websocketpp::server<websocketpp::config::core> s2(std::move(s1));
 }
 
+/*
+// temporary disable because library doesn't pass
 BOOST_AUTO_TEST_CASE( emplace ) {
     std::stringstream out1;
     std::stringstream out2;
@@ -80,7 +82,7 @@ BOOST_AUTO_TEST_CASE( emplace ) {
     v[1].get_alog().write(websocketpp::log::alevel::app,"devel1");
     BOOST_CHECK( out1.str().size() > 0 );
     BOOST_CHECK( out2.str().size() > 0 );
-}
+}*/
 
 #endif // _WEBSOCKETPP_MOVE_SEMANTICS_
 

--- a/test/logger/basic.cpp
+++ b/test/logger/basic.cpp
@@ -85,10 +85,10 @@ BOOST_AUTO_TEST_CASE( basic_concurrency ) {
 
 BOOST_AUTO_TEST_CASE( copy_constructor ) {
     std::stringstream out;
-    
+
     basic_access_log_type logger1(0xffffffff,&out);
     basic_access_log_type logger2(logger1);
-    
+
     logger2.set_channels(0xffffffff);
     logger2.write(websocketpp::log::alevel::devel,"devel");
     BOOST_CHECK( out.str().size() > 0 );
@@ -97,31 +97,35 @@ BOOST_AUTO_TEST_CASE( copy_constructor ) {
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
 BOOST_AUTO_TEST_CASE( move_constructor ) {
     std::stringstream out;
-    
+
     basic_access_log_type logger1(0xffffffff,&out);
     basic_access_log_type logger2(std::move(logger1));
-    
+
     logger2.set_channels(0xffffffff);
     logger2.write(websocketpp::log::alevel::devel,"devel");
     BOOST_CHECK( out.str().size() > 0 );
 }
 
-BOOST_AUTO_TEST_CASE( emplace ) {
+// Emplace requires move assignment, which logger doesn't support right now
+// due to const members. This is pretty irritating and will probably result in
+// the const members being removed. For now though this test will fail to
+// compile
+/*BOOST_AUTO_TEST_CASE( emplace ) {
     std::stringstream out1;
     std::stringstream out2;
-    
+
     std::vector<basic_access_log_type> v;
-    
+
     v.emplace_back(websocketpp::log::level(0xffffffff),&out1);
     v.emplace_back(websocketpp::log::level(0xffffffff),&out2);
-    
+
     v[0].set_channels(0xffffffff);
     v[1].set_channels(0xffffffff);
     v[0].write(websocketpp::log::alevel::devel,"devel");
     v[1].write(websocketpp::log::alevel::devel,"devel");
     BOOST_CHECK( out1.str().size() > 0 );
     BOOST_CHECK( out2.str().size() > 0 );
-}
+}*/
 #endif // #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
 
 // As long as there are const member variables these can't exist
@@ -129,13 +133,13 @@ BOOST_AUTO_TEST_CASE( emplace ) {
 /*BOOST_AUTO_TEST_CASE( copy_assign ) {
     basic_access_log_type logger1;
     basic_access_log_type logger2;
-    
+
     logger2 = logger1;
 }
 
 BOOST_AUTO_TEST_CASE( move_assign ) {
     basic_access_log_type logger1;
     basic_access_log_type logger2;
-    
+
     logger2 = std::move(logger1);
 }*/

--- a/test/logger/basic.cpp
+++ b/test/logger/basic.cpp
@@ -34,6 +34,8 @@
 #include <websocketpp/concurrency/none.hpp>
 #include <websocketpp/concurrency/basic.hpp>
 
+typedef websocketpp::log::basic<websocketpp::concurrency::basic,websocketpp::log::alevel> basic_access_log_type;
+
 BOOST_AUTO_TEST_CASE( is_token_char ) {
     typedef websocketpp::log::basic<websocketpp::concurrency::none,websocketpp::log::elevel> error_log;
 
@@ -79,3 +81,61 @@ BOOST_AUTO_TEST_CASE( basic_concurrency ) {
     //std::cout << "|" << out.str() << "|" << std::endl;
     BOOST_CHECK( out.str().size() > 0 );
 }
+
+
+BOOST_AUTO_TEST_CASE( copy_constructor ) {
+    std::stringstream out;
+    
+    basic_access_log_type logger1(0xffffffff,&out);
+    basic_access_log_type logger2(logger1);
+    
+    logger2.set_channels(0xffffffff);
+    logger2.write(websocketpp::log::alevel::devel,"devel");
+    BOOST_CHECK( out.str().size() > 0 );
+}
+
+BOOST_AUTO_TEST_CASE( move_constructor ) {
+    std::stringstream out;
+    
+    basic_access_log_type logger1(0xffffffff,&out);
+    basic_access_log_type logger2(std::move(logger1));
+    
+    logger2.set_channels(0xffffffff);
+    logger2.write(websocketpp::log::alevel::devel,"devel");
+    BOOST_CHECK( out.str().size() > 0 );
+}
+
+#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+BOOST_AUTO_TEST_CASE( emplace ) {
+    std::stringstream out1;
+    std::stringstream out2;
+    
+    std::vector<basic_access_log_type> v;
+    
+    v.emplace_back(websocketpp::log::level(0xffffffff),&out1);
+    v.emplace_back(websocketpp::log::level(0xffffffff),&out2);
+    
+    v[0].set_channels(0xffffffff);
+    v[1].set_channels(0xffffffff);
+    v[0].write(websocketpp::log::alevel::devel,"devel");
+    v[1].write(websocketpp::log::alevel::devel,"devel");
+    BOOST_CHECK( out1.str().size() > 0 );
+    BOOST_CHECK( out2.str().size() > 0 );
+}
+#endif // #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+
+// As long as there are const member variables these can't exist
+// These remain commented as they are useful for testing the deleted operators
+/*BOOST_AUTO_TEST_CASE( copy_assign ) {
+    basic_access_log_type logger1;
+    basic_access_log_type logger2;
+    
+    logger2 = logger1;
+}
+
+BOOST_AUTO_TEST_CASE( move_assign ) {
+    basic_access_log_type logger1;
+    basic_access_log_type logger2;
+    
+    logger2 = std::move(logger1);
+}*/

--- a/test/logger/basic.cpp
+++ b/test/logger/basic.cpp
@@ -94,6 +94,7 @@ BOOST_AUTO_TEST_CASE( copy_constructor ) {
     BOOST_CHECK( out.str().size() > 0 );
 }
 
+#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
 BOOST_AUTO_TEST_CASE( move_constructor ) {
     std::stringstream out;
     
@@ -105,7 +106,6 @@ BOOST_AUTO_TEST_CASE( move_constructor ) {
     BOOST_CHECK( out.str().size() > 0 );
 }
 
-#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
 BOOST_AUTO_TEST_CASE( emplace ) {
     std::stringstream out1;
     std::stringstream out2;

--- a/test/transport/integration.cpp
+++ b/test/transport/integration.cpp
@@ -607,3 +607,11 @@ BOOST_AUTO_TEST_CASE( pause_reading ) {
 BOOST_AUTO_TEST_CASE( server_connection_cleanup ) {
     server_tls s;
 }
+
+#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+BOOST_AUTO_TEST_CASE( move_construct_transport ) {
+    server s1;
+    
+    server s2(std::move(s1));
+}
+#endif // _WEBSOCKETPP_MOVE_SEMANTICS_

--- a/websocketpp/common/cpp11.hpp
+++ b/websocketpp/common/cpp11.hpp
@@ -80,6 +80,12 @@
     #ifndef _WEBSOCKETPP_NULLPTR_TOKEN_
         #define _WEBSOCKETPP_NULLPTR_TOKEN_ nullptr
     #endif
+    #ifndef _WEBSOCKETPP_MOVE_SEMANTICS_
+        #define _WEBSOCKETPP_MOVE_SEMANTICS_
+    #endif
+    #ifndef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+        #define _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+    #endif
     
     #ifndef __GNUC__
         // GCC as of version 4.9 (latest) does not support std::put_time yet.

--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -104,6 +104,56 @@ public:
         transport_type::init_logging(&m_alog, &m_elog);
     }
 
+
+    /// Destructor
+    ~endpoint<connection,config>() {}
+
+    #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+        // no copy constructor because endpoints are not copyable
+        endpoint(endpoint &) = delete;
+    
+        // no copy assignment operator because endpoints are not copyable
+        endpoint & operator=(endpoint const &) = delete;
+    #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+
+    #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+        /// Move constructor
+        endpoint(endpoint && o) 
+         : config::transport_type(std::move(o))
+         , config::endpoint_base(std::move(o))
+         , m_alog(std::move(o.m_alog))
+         , m_elog(std::move(o.m_elog))
+         , m_user_agent(std::move(o.m_user_agent))
+         , m_open_handler(std::move(o.m_open_handler))
+         
+         , m_close_handler(std::move(o.m_close_handler))
+         , m_fail_handler(std::move(o.m_fail_handler))
+         , m_ping_handler(std::move(o.m_ping_handler))
+         , m_pong_handler(std::move(o.m_pong_handler))
+         , m_pong_timeout_handler(std::move(o.m_pong_timeout_handler))
+         , m_interrupt_handler(std::move(o.m_interrupt_handler))
+         , m_http_handler(std::move(o.m_http_handler))
+         , m_validate_handler(std::move(o.m_validate_handler))
+         , m_message_handler(std::move(o.m_message_handler))
+
+         , m_open_handshake_timeout_dur(o.m_open_handshake_timeout_dur)
+         , m_close_handshake_timeout_dur(o.m_close_handshake_timeout_dur)
+         , m_pong_timeout_dur(o.m_pong_timeout_dur)
+         , m_max_message_size(o.m_max_message_size)
+         , m_max_http_body_size(o.m_max_http_body_size)
+
+         , m_rng(std::move(o.m_rng))
+         , m_is_server(o.m_is_server)         
+        {}
+
+    #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+        // no move assignment operator because of const member variables
+        endpoint & operator=(endpoint &&) = delete;
+    #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+
+    #endif // _WEBSOCKETPP_MOVE_SEMANTICS_
+
+
     /// Returns the user agent string that this endpoint will use
     /**
      * Returns the user agent string that this endpoint will use when creating

--- a/websocketpp/logger/basic.hpp
+++ b/websocketpp/logger/basic.hpp
@@ -80,6 +80,36 @@ public:
       , m_dynamic_channels(0)
       , m_out(out) {}
 
+    /// Destructor
+    ~basic<concurrency,names>() {}
+
+    /// Copy constructor
+    basic<concurrency,names>(basic<concurrency,names> const & other)
+     : m_static_channels(other.m_static_channels)
+     , m_dynamic_channels(other.m_dynamic_channels)
+     , m_out(other.m_out)
+    {}
+    
+#ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+    // no copy assignment operator because of const member variables
+    basic<concurrency,names> & operator=(basic<concurrency,names> const &) = delete;
+#endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+
+#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+    /// Move constructor
+    basic<concurrency,names>(basic<concurrency,names> && other)
+     : m_static_channels(other.m_static_channels)
+     , m_dynamic_channels(other.m_dynamic_channels)
+     , m_out(other.m_out)
+    {}
+
+#ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+    // no move assignment operator because of const member variables
+    basic<concurrency,names> & operator=(basic<concurrency,names> &&) = delete;
+#endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+
+#endif // _WEBSOCKETPP_MOVE_SEMANTICS_
+
     void set_ostream(std::ostream * out = &std::cout) {
         m_out = out;
     }

--- a/websocketpp/processors/hybi13.hpp
+++ b/websocketpp/processors/hybi13.hpp
@@ -563,6 +563,7 @@ public:
         } else {
             frame::extended_header e(i.size());
             out->set_header(frame::prepare_header(h,e));
+            key.i = 0;
         }
 
         // prepare payload

--- a/websocketpp/roles/client_endpoint.hpp
+++ b/websocketpp/roles/client_endpoint.hpp
@@ -29,6 +29,7 @@
 #define WEBSOCKETPP_CLIENT_ENDPOINT_HPP
 
 #include <websocketpp/endpoint.hpp>
+#include <websocketpp/uri.hpp>
 
 #include <websocketpp/logger/levels.hpp>
 

--- a/websocketpp/roles/server_endpoint.hpp
+++ b/websocketpp/roles/server_endpoint.hpp
@@ -69,6 +69,28 @@ public:
         endpoint_type::m_alog.write(log::alevel::devel, "server constructor");
     }
 
+    /// Destructor
+    ~server<config>() {}
+
+#ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+    // no copy constructor because endpoints are not copyable
+    server<config>(server<config> &) = delete;
+    
+    // no copy assignment operator because endpoints are not copyable
+    server<config> & operator=(server<config> const &) = delete;
+#endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+
+#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+    /// Move constructor
+    server<config>(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
+
+#ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+    // no move assignment operator because of const member variables
+    server<config> & operator=(server<config> &&) = delete;
+#endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+
+#endif // _WEBSOCKETPP_MOVE_SEMANTICS_
+
     /// Create and initialize a new connection
     /**
      * The connection will be initialized and ready to begin. Call its start()

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -361,7 +361,7 @@ public:
             callback(lib::error_code());
         }
     }
-protected:
+
     /// Get a pointer to this connection's strand
     strand_ptr get_strand() {
         return m_strand;
@@ -384,6 +384,7 @@ protected:
      * read or write the WebSocket handshakes. At this point the original
      * callback function is called.
      */
+protected:
     void init(init_handler callback) {
         if (m_alog.static_test(log::alevel::devel)) {
             m_alog.write(log::alevel::devel,"asio connection init");

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -37,6 +37,7 @@
 
 #include <websocketpp/base64/base64.hpp>
 #include <websocketpp/error.hpp>
+#include <websocketpp/uri.hpp>
 
 #include <websocketpp/common/cpp11.hpp>
 #include <websocketpp/common/memory.hpp>
@@ -113,6 +114,22 @@ public:
 
     bool is_secure() const {
         return socket_con_type::is_secure();
+    }
+
+    /// Set uri hook
+    /**
+     * Called by the endpoint as a connection is being established to provide
+     * the uri being connected to to the transport layer.
+     *
+     * This transport policy doesn't use the uri except to forward it to the 
+     * socket layer.
+     *
+     * @since 0.6.0
+     *
+     * @param u The uri to set
+     */
+    void set_uri(uri_ptr u) {
+        socket_con_type::set_uri(u);
     }
 
     /// Sets the tcp pre init handler

--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -787,6 +787,8 @@ protected:
                 lib::ref(*m_io_service));
         }
 
+        tcon->set_uri(u);
+
         std::string proxy = tcon->get_proxy();
         std::string host;
         std::string port;

--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -113,23 +113,28 @@ public:
     /// transport::asio objects are moveable but not copyable or assignable.
     /// The following code sets this situation up based on whether or not we
     /// have C++11 support or not
-#ifdef _WEBSOCKETPP_DELETED_FUNCTIONS_
-    endpoint(const endpoint& src) = delete;
+#ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+    endpoint(const endpoint & src) = delete;
     endpoint& operator= (const endpoint & rhs) = delete;
 #else
 private:
-    endpoint(const endpoint& src);
-    endpoint& operator= (const endpoint & rhs);
+    endpoint(const endpoint & src);
+    endpoint & operator= (const endpoint & rhs);
 public:
-#endif
+#endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
-#ifdef _WEBSOCKETPP_RVALUE_REFERENCES_
-    endpoint (endpoint&& src)
-      : m_io_service(src.m_io_service)
+#ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+    endpoint (endpoint && src)
+      : config::socket_type(std::move(src))
+      , m_tcp_pre_init_handler(src.m_tcp_pre_init_handler)
+      , m_tcp_post_init_handler(src.m_tcp_post_init_handler)
+      , m_io_service(src.m_io_service)
       , m_external_io_service(src.m_external_io_service)
       , m_acceptor(src.m_acceptor)
       , m_listen_backlog(boost::asio::socket_base::max_connections)
       , m_reuse_addr(src.m_reuse_addr)
+      , m_elog(src.m_elog)
+      , m_alog(src.m_alog)
       , m_state(src.m_state)
     {
         src.m_io_service = NULL;
@@ -138,7 +143,7 @@ public:
         src.m_state = UNINITIALIZED;
     }
 
-    endpoint& operator= (const endpoint && rhs) {
+    /*endpoint & operator= (const endpoint && rhs) {
         if (this != &rhs) {
             m_io_service = rhs.m_io_service;
             m_external_io_service = rhs.m_external_io_service;
@@ -152,10 +157,13 @@ public:
             rhs.m_acceptor = NULL;
             rhs.m_listen_backlog = boost::asio::socket_base::max_connections;
             rhs.m_state = UNINITIALIZED;
+            
+            // TODO: this needs to be updated
         }
         return *this;
-    }
-#endif
+    }*/
+#endif // _WEBSOCKETPP_MOVE_SEMANTICS_
+
     /// Return whether or not the endpoint produces secure connections.
     bool is_secure() const {
         return socket_type::is_secure();

--- a/websocketpp/transport/asio/security/base.hpp
+++ b/websocketpp/transport/asio/security/base.hpp
@@ -56,6 +56,7 @@
 
 // Connection
 // TODO
+// set_hostname(std::string hostname)
 // pre_init(init_handler);
 // post_init(init_handler);
 
@@ -97,7 +98,10 @@ namespace error {
         missing_tls_init_handler,
 
         /// TLS Handshake Failed
-        tls_handshake_failed
+        tls_handshake_failed,
+        
+        /// Failed to set TLS SNI hostname
+        tls_failed_sni_hostname
     };
 } // namespace error
 
@@ -126,6 +130,8 @@ public:
                 return "Required tls_init handler not present.";
             case error::tls_handshake_failed:
                 return "TLS handshake failed";
+            case error::tls_failed_sni_hostname:
+                return "Failed to set TLS SNI hostname";
             default:
                 return "Unknown";
         }

--- a/websocketpp/transport/asio/security/none.hpp
+++ b/websocketpp/transport/asio/security/none.hpp
@@ -28,6 +28,8 @@
 #ifndef WEBSOCKETPP_TRANSPORT_SECURITY_NONE_HPP
 #define WEBSOCKETPP_TRANSPORT_SECURITY_NONE_HPP
 
+#include <websocketpp/uri.hpp>
+
 #include <websocketpp/transport/asio/security/base.hpp>
 
 #include <websocketpp/common/memory.hpp>
@@ -173,6 +175,19 @@ protected:
 
         return lib::error_code();
     }
+
+    /// Set uri hook
+    /**
+     * Called by the transport as a connection is being established to provide
+     * the uri being connected to to the security/socket layer.
+     *
+     * This socket policy doesn't use the uri so it is ignored.
+     *
+     * @since 0.6.0
+     *
+     * @param u The uri to set
+     */
+    void set_uri(uri_ptr) {}
 
     /// Pre-initialize security policy
     /**

--- a/websocketpp/transport/debug/connection.hpp
+++ b/websocketpp/transport/debug/connection.hpp
@@ -32,6 +32,7 @@
 
 #include <websocketpp/transport/base/connection.hpp>
 
+#include <websocketpp/uri.hpp>
 #include <websocketpp/logger/levels.hpp>
 
 #include <websocketpp/common/connection_hdl.hpp>
@@ -102,6 +103,20 @@ public:
     bool is_secure() const {
         return false;
     }
+
+    /// Set uri hook
+    /**
+     * Called by the endpoint as a connection is being established to provide
+     * the uri being connected to to the transport layer.
+     *
+     * Implementation is optional and can be ignored if the transport has no
+     * need for this information.
+     *
+     * @since 0.6.0
+     *
+     * @param u The uri to set
+     */
+    void set_uri(uri_ptr) {}
 
     /// Set human readable remote endpoint address
     /**

--- a/websocketpp/transport/iostream/base.hpp
+++ b/websocketpp/transport/iostream/base.hpp
@@ -33,7 +33,10 @@
 #include <websocketpp/common/functional.hpp>
 #include <websocketpp/common/connection_hdl.hpp>
 
+#include <websocketpp/transport/base/connection.hpp>
+
 #include <string>
+#include <vector>
 
 namespace websocketpp {
 namespace transport {
@@ -41,10 +44,19 @@ namespace transport {
 namespace iostream {
 
 /// The type and signature of the callback used by iostream transport to write
-typedef lib::function<lib::error_code(connection_hdl, char const *, size_t)> 
+typedef lib::function<lib::error_code(connection_hdl, char const *, size_t)>
     write_handler;
 
-/// The type and signature of the callback used by iostream transport to signal 
+/// The type and signature of the callback used by iostream transport to perform
+/// vectored writes.
+/**
+ * If a vectored write handler is not set the standard write handler will be
+ * called multiple times.
+ */
+typedef lib::function<lib::error_code(connection_hdl, std::vector<transport::buffer> const
+    & bufs)> vector_write_handler;
+
+/// The type and signature of the callback used by iostream transport to signal
 /// a transport shutdown.
 typedef lib::function<lib::error_code(connection_hdl)> shutdown_handler;
 

--- a/websocketpp/transport/iostream/connection.hpp
+++ b/websocketpp/transport/iostream/connection.hpp
@@ -168,7 +168,7 @@ public:
 
         return this->read_some_impl(buf,len);
     }
-    
+
     /// Manual input supply (read all)
     /**
      * Similar to read_some, but continues to read until all bytes in the
@@ -188,7 +188,7 @@ public:
     size_t read_all(char const * buf, size_t len) {
         // this serializes calls to external read.
         scoped_lock_type lock(m_read_mutex);
-        
+
         size_t total_read = 0;
         size_t temp_read = 0;
 
@@ -327,25 +327,60 @@ public:
     timer_ptr set_timer(long, timer_handler) {
         return timer_ptr();
     }
-    
+
     /// Sets the write handler
     /**
      * The write handler is called when the iostream transport receives data
      * that needs to be written to the appropriate output location. This handler
      * can be used in place of registering an ostream for output.
      *
-     * The signature of the handler is 
+     * The signature of the handler is
      * `lib::error_code (connection_hdl, char const *, size_t)` The
      * code returned will be reported and logged by the core library.
      *
+     * See also, set_vector_write_handler, for an optional write handler that
+     * allows more efficient handling of multiple writes at once.
+     *
+     * @see set_vector_write_handler
+     *
      * @since 0.5.0
      *
-     * @param h The handler to call on connection shutdown.
+     * @param h The handler to call when data is to be written.
      */
     void set_write_handler(write_handler h) {
         m_write_handler = h;
     }
-    
+
+    /// Sets the vectored write handler
+    /**
+     * The vectored write handler is called when the iostream transport receives
+     * multiple chunks of data that need to be written to the appropriate output
+     * location. This handler can be used in conjunction with the write_handler
+     * in place of registering an ostream for output.
+     *
+     * The sequence of buffers represents bytes that should be written
+     * consecutively and it is suggested to group the buffers into as few next
+     * layer packets as possible. Vector write is used to allow implementations
+     * that support it to coalesce writes into a single TCP packet or TLS
+     * segment for improved efficiency.
+     *
+     * This is an optional handler. If it is not defined then multiple calls
+     * will be made to the standard write handler.
+     *
+     * The signature of the handler is
+     * `lib::error_code (connection_hdl, std::vector<websocketpp::transport::buffer>
+     * const & bufs)`. The code returned will be reported and logged by the core
+     * library. The `websocketpp::transport::buffer` type is a struct with two
+     * data members. buf (char const *) and len (size_t).
+     *
+     * @since 0.6.0
+     *
+     * @param h The handler to call when vectored data is to be written.
+     */
+    void set_vector_write_handler(vector_write_handler h) {
+        m_vector_write_handler = h;
+    }
+
     /// Sets the shutdown handler
     /**
      * The shutdown handler is called when the iostream transport receives a
@@ -449,7 +484,7 @@ protected:
      * @param len number of bytes to write
      * @param handler Callback to invoke with operation status.
      */
-    void async_write(char const * buf, size_t len, transport::write_handler 
+    void async_write(char const * buf, size_t len, transport::write_handler
         handler)
     {
         m_alog.write(log::alevel::devel,"iostream_con async_write");
@@ -459,7 +494,7 @@ protected:
 
         if (m_output_stream) {
             m_output_stream->write(buf,len);
-            
+
             if (m_output_stream->bad()) {
                 ec = make_error_code(error::bad_stream);
             }
@@ -507,17 +542,19 @@ protected:
                     break;
                 }
             }
+        } else if (m_vector_write_handler) {
+            ec = m_vector_write_handler(m_connection_hdl, bufs);
         } else if (m_write_handler) {
             std::vector<buffer>::const_iterator it;
             for (it = bufs.begin(); it != bufs.end(); it++) {
                 ec = m_write_handler(m_connection_hdl, (*it).buf, (*it).len);
                 if (ec) {break;}
             }
-            
+
         } else {
             ec = make_error_code(error::output_stream_required);
         }
-        
+
         handler(ec);
     }
 
@@ -555,11 +592,11 @@ protected:
      */
     void async_shutdown(transport::shutdown_handler handler) {
         lib::error_code ec;
-        
+
         if (m_shutdown_handler) {
             ec = m_shutdown_handler(m_connection_hdl);
         }
-        
+
         handler(ec);
     }
 private:
@@ -651,6 +688,7 @@ private:
     std::ostream *  m_output_stream;
     connection_hdl  m_connection_hdl;
     write_handler   m_write_handler;
+    vector_write_handler m_vector_write_handler;
     shutdown_handler    m_shutdown_handler;
 
     bool            m_reading;

--- a/websocketpp/transport/iostream/connection.hpp
+++ b/websocketpp/transport/iostream/connection.hpp
@@ -32,6 +32,8 @@
 
 #include <websocketpp/transport/base/connection.hpp>
 
+#include <websocketpp/uri.hpp>
+
 #include <websocketpp/logger/levels.hpp>
 
 #include <websocketpp/common/connection_hdl.hpp>
@@ -104,6 +106,19 @@ public:
         scoped_lock_type lock(m_read_mutex);
         m_output_stream = o;
     }
+
+    /// Set uri hook
+    /**
+     * Called by the endpoint as a connection is being established to provide
+     * the uri being connected to to the transport layer.
+     *
+     * This transport policy doesn't use the uri so it is ignored.
+     *
+     * @since 0.6.0
+     *
+     * @param u The uri to set
+     */
+    void set_uri(uri_ptr) {}
 
     /// Overloaded stream input operator
     /**

--- a/websocketpp/transport/stub/connection.hpp
+++ b/websocketpp/transport/stub/connection.hpp
@@ -103,6 +103,20 @@ public:
         return false;
     }
 
+    /// Set uri hook
+    /**
+     * Called by the endpoint as a connection is being established to provide
+     * the uri being connected to to the transport layer.
+     *
+     * Implementation is optional and can be ignored if the transport has no
+     * need for this information.
+     *
+     * @since 0.6.0
+     *
+     * @param u The uri to set
+     */
+    void set_uri(uri_ptr) {}
+
     /// Set human readable remote endpoint address
     /**
      * Sets the remote endpoint address returned by `get_remote_endpoint`. This

--- a/websocketpp/version.hpp
+++ b/websocketpp/version.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Peter Thorson. All rights reserved.
+ * Copyright (c) 2015, Peter Thorson. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -50,10 +50,10 @@ static int const patch_version = 0;
  * This is a textual flag indicating the type and number for pre-release
  * versions (dev, alpha, beta, rc). This will be blank for release versions.
  */
-static char const prerelease_flag[] = "";
+static char const prerelease_flag[] = "dev";
 
 /// Default user agent string
-static char const user_agent[] = "WebSocket++/0.5.0";
+static char const user_agent[] = "WebSocket++/0.5.x-dev";
 
 } // namespace websocketpp
 


### PR DESCRIPTION
Hello!  We find that we need to get the strand from the connection, and there's no other reasonable way to do so.  Let me know if I'm missing something!