### PR TITLE
Fix dangling pointer and message in error.hpp.

### DIFF
--- a/websocketpp/error.hpp
+++ b/websocketpp/error.hpp
@@ -250,7 +250,7 @@ public:
     {}
 
     explicit exception(lib::error_code ec)
-      : m_code(ec)
+      : m_msg(ec.message()), m_code(ec)
     {}
 
     ~exception() throw() {}
@@ -263,7 +263,7 @@ public:
         return m_code;
     }
 
-    std::string m_msg;
+    const std::string m_msg;
     lib::error_code m_code;
 };
 


### PR DESCRIPTION
Two little problems still in this file.

1. `what()` returns a `const char*` that comes from a `std::string`.  If the `std::string` changes, the `const char*` might become invalid, resulting in undefined behavior.

2. The first and second constructors of `exception` are inconsistent.  In the first one, if there's no message the message from the error code is used.  In the second one, there's no message, even though there's an error code provided.

My solution to the first problem was simply to make that one `std::string` member `const`.  It will break any code that changes the `m_msg` on an `exception` - but if they did that, they were flirting with UB anyway - and everything else should work unchanged.