### PR TITLE
Remove bad add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,11 +224,6 @@ if (BUILD_EXAMPLES)
     add_subdirectory (examples)
 endif ()
 
-# Add tests
-if (BUILD_TESTS)
-    add_subdirectory (test)
-endif ()
-
 print_used_build_config()
 
 export (PACKAGE websocketpp)


### PR DESCRIPTION
This isn't actually needed, because there is no CMakeLists.txt file in tests directory
"CMake Warning (dev) at CMakeLists.txt:229 (add_subdirectory):
  The source directory
    /tmp/build/websocketpp/test
  does not contain a CMakeLists.txt file.
  CMake does not support this case but it used to work accidentally and is
  being allowed for compatibility.
  Policy CMP0014 is not set: Input directories must have CMakeLists.txt.  Run
  "cmake --help-policy CMP0014" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it."