### PR TITLE
Fix MSVC default install path setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,9 @@ set (WEBSOCKETPP_LIB ${WEBSOCKETPP_BUILD_ROOT}/lib)
 # - Windows: Build the INSTALL project in your solution file.
 # - Linux/OSX: make install.
 if (MSVC)
-    set (CMAKE_INSTALL_PREFIX "${WEBSOCKETPP_ROOT}/install")
+  if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set (CMAKE_INSTALL_PREFIX "${WEBSOCKETPP_ROOT}/install" CACHE PATH "Install Prefix" FORCE)
+  endif ()
 endif ()
 
 ############  Build customization


### PR DESCRIPTION
The set command was not using CACHE, and so was creating a local variable that conflicted with the CMake variable that's actually used leading to strange. FORCE must also be used since it is set by default, so in order to avoid stomping on user-configured settings, the CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT variable must be checked.