### PR TITLE
Fix asio strand class name

### DIFF
--- a/websocketpp/common/asio_ssl.hpp
+++ b/websocketpp/common/asio_ssl.hpp
@@ -29,7 +29,7 @@
 #define WEBSOCKETPP_COMMON_ASIO_SSL_HPP
 
 #ifdef ASIO_STANDALONE
-    #include <asio/asio/ssl.hpp>
+    #include <asio/ssl.hpp>
 #else
     #include <boost/asio/ssl.hpp>
 #endif

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -439,7 +439,7 @@ protected:
         m_io_service = io_service;
 
         if (config::enable_multithreading) {
-            m_strand = lib::make_shared<lib::asio::strand>(
+            m_strand = lib::make_shared<lib::asio::io_service::strand>(
                 lib::ref(*io_service));
 
             m_async_read_handler = m_strand->wrap(lib::bind(

--- a/websocketpp/transport/asio/security/tls.hpp
+++ b/websocketpp/transport/asio/security/tls.hpp
@@ -334,7 +334,7 @@ protected:
      * @param ec The error code to translate_ec
      * @return The translated error code
      */
-    lib::error_code translate_ec(boost::system::error_code ec) {
+    lib::error_code translate_ec(lib::error_code ec) {
         if (ec.category() == lib::asio::error::get_ssl_category()) {
             if (ERR_GET_REASON(ec.value()) == SSL_R_SHORT_READ) {
                 return make_error_code(transport::error::tls_short_read);


### PR DESCRIPTION
Correct class name should be asio::io_service::strand. asio::strand is not working with recent asio version.