### PR TITLE
Fix memory leak when init_asio produces an error (develop branch)

### DIFF
--- a/websocketpp/common/memory.hpp
+++ b/websocketpp/common/memory.hpp
@@ -65,6 +65,7 @@ namespace lib {
 #ifdef _WEBSOCKETPP_CPP11_MEMORY_
     using std::shared_ptr;
     using std::weak_ptr;
+    using std::auto_ptr;
     using std::enable_shared_from_this;
     using std::static_pointer_cast;
     using std::make_shared;
@@ -73,6 +74,7 @@ namespace lib {
 #else
     using boost::shared_ptr;
     using boost::weak_ptr;
+    using std::auto_ptr;
     using boost::enable_shared_from_this;
     using boost::static_pointer_cast;
     using boost::make_shared;

--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -218,7 +218,10 @@ public:
      * @param ec Set to indicate what error occurred, if any.
      */
     void init_asio(lib::error_code & ec) {
-        init_asio(new lib::asio::io_service(), ec);
+        // Use a smart pointer until the call is successful and ownership has successfully been taken
+        lib::auto_ptr<lib::asio::io_service> pService(new lib::asio::io_service());
+        init_asio(pService.get(), ec);
+        if( !ec ) pService.release(); // Call was successful, transfer ownership
         m_external_io_service = false;
     }
 
@@ -230,7 +233,11 @@ public:
      * @see init_asio(io_service_ptr ptr)
      */
     void init_asio() {
-        init_asio(new lib::asio::io_service());
+        // Use a smart pointer until the call is successful and ownership transferred
+        lib::auto_ptr<lib::asio::io_service> pService(new lib::asio::io_service());
+        init_asio( pService.get() );
+        // If control got this far without an exception, then ownership has successfully been taken
+        pService.release();
         m_external_io_service = false;
     }
 


### PR DESCRIPTION
Version of #453 on the develop branch.  Description copied from there:

Currently the init_asio functions that don't use an external io_service will leak the memory if an error is generated. This uses a smart pointer to temporarily hold the new io_service until it is confirmed the function has completed successfully and ownership taken.

Couldn't use a unique_ptr because this wouldn't work with non-C++11 systems. Couldn't use shared_ptr because it has no release() method.