### PR TITLE
fix crash in strip_lws()

### DIFF
--- a/test/http/parser.cpp
+++ b/test/http/parser.cpp
@@ -365,6 +365,7 @@ BOOST_AUTO_TEST_CASE( strip_lws ) {
     std::string test6 = "  \r\n  foo     ";
     std::string test7 = "  \t  foo     ";
     std::string test8 = "  \t       ";
+    std::string test9 = " \n\r";
 
     BOOST_CHECK_EQUAL( websocketpp::http::parser::strip_lws(test1), "foo" );
     BOOST_CHECK_EQUAL( websocketpp::http::parser::strip_lws(test2), "foo" );
@@ -374,6 +375,7 @@ BOOST_AUTO_TEST_CASE( strip_lws ) {
     BOOST_CHECK_EQUAL( websocketpp::http::parser::strip_lws(test6), "foo" );
     BOOST_CHECK_EQUAL( websocketpp::http::parser::strip_lws(test7), "foo" );
     BOOST_CHECK_EQUAL( websocketpp::http::parser::strip_lws(test8), "" );
+    BOOST_CHECK_EQUAL( websocketpp::http::parser::strip_lws(test9), "" );
 }
 
 BOOST_AUTO_TEST_CASE( case_insensitive_headers ) {

--- a/websocketpp/http/parser.hpp
+++ b/websocketpp/http/parser.hpp
@@ -381,9 +381,13 @@ inline std::string strip_lws(std::string const & input) {
     if (begin == input.end()) {
         return std::string();
     }
-    std::string::const_reverse_iterator end = extract_all_lws(input.rbegin(),input.rend());
 
-    return std::string(begin,end.base());
+    std::string::const_reverse_iterator rbegin = extract_all_lws(input.rbegin(),input.rend());
+    if (rbegin == input.rend()) {
+        return std::string();
+    }
+
+    return std::string(begin,rbegin.base());
 }
 
 /// Base HTTP parser


### PR DESCRIPTION
Before this fix, a malicious client could cause a websocketpp server to create an invalid std::string.