### PR TITLE
Add send_empty_handler callback when the send queue is empty.

### DIFF
--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -150,6 +150,13 @@ typedef lib::function<bool(connection_hdl)> validate_handler;
  */
 typedef lib::function<void(connection_hdl)> http_handler;
 
+/// The type and function signature of an send_empty handler
+/**
+ * The send_empty handler is called when the send queue becomes empty of
+ * messages.
+ */
+typedef lib::function<void(connection_hdl)> send_empty_handler;
+
 //
 typedef lib::function<void(lib::error_code const & ec, size_t bytes_transferred)> read_handler;
 typedef lib::function<void(lib::error_code const & ec)> write_frame_handler;
@@ -472,6 +479,16 @@ public:
      */
     void set_message_handler(message_handler h) {
         m_message_handler = h;
+    }
+
+    /// Set send empty handler
+    /**
+     * The send empty handler is called when the message queue is empty.
+     *
+     * @param h The new message_handler
+     */
+    void set_send_empty_handler(send_empty_handler h) {
+        m_send_empty_handler = h;
     }
 
     //////////////////////////////////////////
@@ -1455,7 +1472,8 @@ private:
     http_handler            m_http_handler;
     validate_handler        m_validate_handler;
     message_handler         m_message_handler;
-
+    send_empty_handler      m_send_empty_handler;
+ 
     /// constant values
     long                    m_open_handshake_timeout_dur;
     long                    m_close_handshake_timeout_dur;

--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -135,6 +135,7 @@ public:
          , m_http_handler(std::move(o.m_http_handler))
          , m_validate_handler(std::move(o.m_validate_handler))
          , m_message_handler(std::move(o.m_message_handler))
+         , m_send_empty_handler(std::move(o.m_send_empty_handler))
 
          , m_open_handshake_timeout_dur(o.m_open_handshake_timeout_dur)
          , m_close_handshake_timeout_dur(o.m_close_handshake_timeout_dur)
@@ -320,6 +321,11 @@ public:
         m_alog.write(log::alevel::devel,"set_message_handler");
         scoped_lock_type guard(m_mutex);
         m_message_handler = h;
+    }
+    void set_send_empty_handler(send_empty_handler h) {
+        m_alog.write(log::alevel::devel,"set_send_empty_handler");
+        scoped_lock_type guard(m_mutex);
+        m_send_empty_handler = h;
     }
 
     //////////////////////////////////////////
@@ -674,7 +680,8 @@ private:
     http_handler                m_http_handler;
     validate_handler            m_validate_handler;
     message_handler             m_message_handler;
-
+    send_empty_handler          m_send_empty_handler;
+    
     long                        m_open_handshake_timeout_dur;
     long                        m_close_handshake_timeout_dur;
     long                        m_pong_timeout_dur;

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -1804,6 +1804,7 @@ void connection<config>::write_frame() {
         // pull off all the messages that are ready to write.
         // stop if we get a message marked terminal
         message_ptr next_message = write_pop();
+        bool sent_message = next_message;
         while (next_message) {
             m_current_msgs.push_back(next_message);
             if (!next_message->get_terminal()) {
@@ -1815,6 +1816,10 @@ void connection<config>::write_frame() {
         
         if (m_current_msgs.empty()) {
             // there was nothing to send
+            
+            // If we made the transition to an empty queue, call "send_empty".
+            if (sent_message && m_send_empty_handler)
+                m_send_empty_handler(m_connection_hdl);
             return;
         } else {
             // At this point we own the next messages to be sent and are

--- a/websocketpp/impl/endpoint_impl.hpp
+++ b/websocketpp/impl/endpoint_impl.hpp
@@ -66,6 +66,7 @@ endpoint<connection,config>::create_connection() {
     con->set_http_handler(m_http_handler);
     con->set_validate_handler(m_validate_handler);
     con->set_message_handler(m_message_handler);
+    con->set_send_empty_handler(m_send_empty_handler);
 
     if (m_open_handshake_timeout_dur != config::timeout_open_handshake) {
         con->set_open_handshake_timeout(m_open_handshake_timeout_dur);


### PR DESCRIPTION
Hello!  I think we discussed this feature before in the distant past... :-)

Basically, we need the idea of "backpressure" in our application - if a connection isn't picking up its messages, then we stop preparing them until they do.  This protects us from badly-written clients, network issues, etc.

To that end, we have added a callback from websocketpp when the `m_current_msgs` queue becomes empty.  The cost should be marginal if you don't use the feature.

Let me know what you think!  Thanks in advance.

(I ran all the unit tests by `find`ing all the test binaries and running them - is there an official way to do this?)