### PR TITLE
Fix race condition problem in transport::asio::connection

### DIFF
--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -441,21 +441,13 @@ protected:
         if (config::enable_multithreading) {
             m_strand = lib::make_shared<lib::asio::strand>(
                 lib::ref(*io_service));
-
-            m_async_read_handler = m_strand->wrap(lib::bind(
-                &type::handle_async_read, get_shared(),lib::placeholders::_1,
-                lib::placeholders::_2));
-
-            m_async_write_handler = m_strand->wrap(lib::bind(
-                &type::handle_async_write, get_shared(),lib::placeholders::_1,
-                lib::placeholders::_2));
-        } else {
-            m_async_read_handler = lib::bind(&type::handle_async_read,
-                get_shared(), lib::placeholders::_1, lib::placeholders::_2);
-
-            m_async_write_handler = lib::bind(&type::handle_async_write,
-                get_shared(), lib::placeholders::_1, lib::placeholders::_2);
         }
+
+        m_async_read_handler = lib::bind(&type::handle_async_read,
+          get_shared(), lib::placeholders::_1, lib::placeholders::_2);
+
+        m_async_write_handler = lib::bind(&type::handle_async_write,
+          get_shared(), lib::placeholders::_1, lib::placeholders::_2);
 
         lib::error_code ec = socket_con_type::init_asio(io_service, m_strand,
             m_is_server);
@@ -853,15 +845,22 @@ protected:
                 "asio con async_read_at_least called with bad handler");
         }
 
-        lib::asio::async_read(
-            socket_con_type::get_socket(),
-            lib::asio::buffer(buf,len),
-            lib::asio::transfer_at_least(num_bytes),
-            make_custom_alloc_handler(
-                m_read_handler_allocator,
-                m_async_read_handler
-            )
-        );
+        if (config::enable_multithreading) {
+            lib::asio::async_read(
+        		    socket_con_type::get_socket(),
+        		    lib::asio::buffer(buf,len),
+        		    lib::asio::transfer_at_least(num_bytes),
+        		    m_strand->wrap(m_async_read_handler)
+        		);
+        }
+        else {
+            lib::asio::async_read(
+        		    socket_con_type::get_socket(),
+        		    lib::asio::buffer(buf,len),
+        		    lib::asio::transfer_at_least(num_bytes),
+        		    m_async_read_handler
+        		);
+        }
     }
 
     void handle_async_read(lib::asio::error_code const & ec,
@@ -911,14 +910,20 @@ protected:
 
         m_write_handler = handler;
 
-        lib::asio::async_write(
-            socket_con_type::get_socket(),
-            m_bufs,
-            make_custom_alloc_handler(
-                m_write_handler_allocator,
-                m_async_write_handler
-            )
-        );
+        if (config::enable_multithreading) {
+            lib::asio::async_write(
+        		    socket_con_type::get_socket(),
+        		    m_bufs,
+        		    m_strand->wrap(m_async_write_handler)
+        		);
+        }
+        else {
+            lib::asio::async_write(
+        		    socket_con_type::get_socket(),
+        		    m_bufs,
+        		    m_async_write_handler
+        		);
+        }
     }
 
     void async_write(std::vector<buffer> const & bufs, write_handler handler) {
@@ -936,14 +941,20 @@ protected:
 
         m_write_handler = handler;
 
-        lib::asio::async_write(
-            socket_con_type::get_socket(),
-            m_bufs,
-            make_custom_alloc_handler(
-                m_write_handler_allocator,
-                m_async_write_handler
-            )
-        );
+        if (config::enable_multithreading) {
+            lib::asio::async_write(
+        		    socket_con_type::get_socket(),
+        		    m_bufs,
+        		    m_strand->wrap(m_async_write_handler)
+        		);
+        }
+        else {
+            lib::asio::async_write(
+        		    socket_con_type::get_socket(),
+        		    m_bufs,
+        		    m_async_write_handler
+        		);
+        }
     }
 
     /// Async write callback

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -847,19 +847,24 @@ protected:
 
         if (config::enable_multithreading) {
             lib::asio::async_read(
-        		    socket_con_type::get_socket(),
-        		    lib::asio::buffer(buf,len),
-        		    lib::asio::transfer_at_least(num_bytes),
-        		    m_strand->wrap(m_async_read_handler)
-        		);
+                    socket_con_type::get_socket(),
+                    lib::asio::buffer(buf,len),
+                    lib::asio::transfer_at_least(num_bytes),
+                    m_strand->wrap(
+                        make_custom_alloc_handler(
+                            m_read_handler_allocator,
+                            m_async_read_handler))
+                );
         }
         else {
             lib::asio::async_read(
-        		    socket_con_type::get_socket(),
-        		    lib::asio::buffer(buf,len),
-        		    lib::asio::transfer_at_least(num_bytes),
-        		    m_async_read_handler
-        		);
+                    socket_con_type::get_socket(),
+                    lib::asio::buffer(buf,len),
+                    lib::asio::transfer_at_least(num_bytes),
+                    make_custom_alloc_handler(
+                        m_read_handler_allocator,
+                        m_async_read_handler)
+                );
         }
     }
 
@@ -912,17 +917,22 @@ protected:
 
         if (config::enable_multithreading) {
             lib::asio::async_write(
-        		    socket_con_type::get_socket(),
-        		    m_bufs,
-        		    m_strand->wrap(m_async_write_handler)
-        		);
+                    socket_con_type::get_socket(),
+                    m_bufs,
+                    m_strand->wrap(
+                        make_custom_alloc_handler(
+                            m_write_handler_allocator,
+                            m_async_write_handler))
+                );
         }
         else {
             lib::asio::async_write(
-        		    socket_con_type::get_socket(),
-        		    m_bufs,
-        		    m_async_write_handler
-        		);
+                    socket_con_type::get_socket(),
+                    m_bufs,
+                    make_custom_alloc_handler(
+                        m_write_handler_allocator,
+                        m_async_write_handler)
+                );
         }
     }
 
@@ -943,17 +953,22 @@ protected:
 
         if (config::enable_multithreading) {
             lib::asio::async_write(
-        		    socket_con_type::get_socket(),
-        		    m_bufs,
-        		    m_strand->wrap(m_async_write_handler)
-        		);
+                    socket_con_type::get_socket(),
+                    m_bufs,
+                    m_strand->wrap(
+                        make_custom_alloc_handler(
+                            m_write_handler_allocator,
+                            m_async_write_handler))
+                );
         }
         else {
             lib::asio::async_write(
-        		    socket_con_type::get_socket(),
-        		    m_bufs,
-        		    m_async_write_handler
-        		);
+                    socket_con_type::get_socket(),
+                    m_bufs,
+                    make_custom_alloc_handler(
+                        m_write_handler_allocator,
+                        m_async_write_handler)
+                );
         }
     }
 

--- a/websocketpp/transport/asio/security/tls.hpp
+++ b/websocketpp/transport/asio/security/tls.hpp
@@ -316,7 +316,10 @@ protected:
     }
 
     void async_shutdown(socket_shutdown_handler callback) {
-        m_socket->async_shutdown(callback);
+        if (m_strand)
+            m_socket->async_shutdown(m_strand->wrap(callback));
+        else
+            m_socket->async_shutdown(callback);
     }
 
     /// Translate any security policy specific information about an error code


### PR DESCRIPTION
There are some issues about race condition on asio server and I also have same problem.
* https://github.com/zaphoyd/websocketpp/issues/459

So I made some changes to fix the problem.
Please review.

===========

Make sure that all handlers are wrapped by asio::io_service::strand.
These are some cases that cause intermediate handler or final handler is not synchronized.
 1. custom_alloc_handler or std::function prevents calling asio_handler_invoke for asio::io_service::strand.
 2. handler for async_shutdown is not wrapped by strand.