### PR TITLE
Fix make_shared using the wrong strand type

### DIFF
--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -439,7 +439,7 @@ protected:
         m_io_service = io_service;
 
         if (config::enable_multithreading) {
-            m_strand = lib::make_shared<lib::asio::strand>(
+            m_strand = lib::make_shared<lib::asio::io_service::strand>(
                 lib::ref(*io_service));
 
             m_async_read_handler = m_strand->wrap(lib::bind(


### PR DESCRIPTION
Fix compilation with standalone ASIO (#462), where asio::strand and asio::io_service::strand are separate types.
This is the correct type, as m_strand is a ``lib::shared_ptr<lib::asio::io_service::strand>``

Tested on mingw64 5.1