### PR TITLE
Always log errors when cancelling sockets

### DIFF
--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -584,7 +584,7 @@ protected:
                 // cancel not supported on this OS, ignore and log at dev level
                 m_alog.write(log::alevel::devel, "socket cancel not supported");
             } else {
-                m_elog.write(log::elevel::warn, "socket cancel failed");
+                log_err(log::elevel::warn, "socket cancel failed", cec);
             }
         }
         callback(ret_ec);

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -584,7 +584,7 @@ protected:
                 // cancel not supported on this OS, ignore and log at dev level
                 m_alog.write(log::alevel::devel, "socket cancel not supported");
             } else {
-                m_alog.write(log::elevel::warn, "socket cancel failed");
+                m_elog.write(log::elevel::warn, "socket cancel failed");
             }
         }
         callback(ret_ec);

--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -1027,7 +1027,7 @@ protected:
         }
 
         m_alog->write(log::alevel::devel,"TCP connect timed out");
-        tcon->cancel_socket();
+        tcon->cancel_socket_checked();
         callback(ret_ec);
     }
 


### PR DESCRIPTION
I'm still actively hunting down a socket cancellation exception, but in the meantime, I found these three patches useful.