### PR TITLE
Fix detection of noexcept on vs2015 and problem with boost chrono

### DIFF
--- a/websocketpp/common/asio.hpp
+++ b/websocketpp/common/asio.hpp
@@ -101,9 +101,15 @@ namespace lib {
             bool is_neg(T duration) {
                 return duration.count() < 0;
             }
-            inline lib::chrono::milliseconds milliseconds(long duration) {
-                return lib::chrono::milliseconds(duration);
-            }
+            #if defined(BOOST_ASIO_HAS_STD_CHRONO)
+                inline std::chrono::milliseconds milliseconds(long duration) {
+                    return std::chrono::milliseconds(duration);
+                }
+            #else
+                inline lib::chrono::milliseconds milliseconds(long duration) {
+                    return lib::chrono::milliseconds(duration);
+                }
+            #endif
         #else
             // Using boost::asio <1.49 we pretend a deadline timer is a steady
             // timer and wrap the negative detection and duration conversion

--- a/websocketpp/common/cpp11.hpp
+++ b/websocketpp/common/cpp11.hpp
@@ -102,7 +102,7 @@
             // build system says we have noexcept
             #define _WEBSOCKETPP_NOEXCEPT_TOKEN_ noexcept
         #else
-            #if __has_feature(cxx_noexcept)
+            #if __has_feature(cxx_noexcept) || _MSC_VER > 1800
                 // clang feature detect says we have noexcept
                 #define _WEBSOCKETPP_NOEXCEPT_TOKEN_ noexcept
             #else


### PR DESCRIPTION
Hi,

I try to build a program using websocketpp with visual studio 2015 and get this error:

```
'const char *websocketpp::error::category::name(void) const': overriding virtual function has less restrictive exception specification than base class virtual member function 'const char *boost::system::error_category::name(void) noexcept const'	websocket-basics	websocketpp\error.hpp	151	
```

it seems that boost has BOOST_SYSTEM_NOEXCEPT set to noexcept, but websocketpp seems not to set its _WEBSOCKETPP_NOEXCEPT_TOKEN_ correctly, since visual studio compiler does not set __has_feature correctly

I also get the same like in #437 so I added the bugfix by @emfrias for that too