### PR TITLE
added subprotocol support for hybi00 / hixie76

### DIFF
--- a/websocketpp/processors/hybi00.hpp
+++ b/websocketpp/processors/hybi00.hpp
@@ -186,15 +186,29 @@ public:
 
     /// Extracts requested subprotocols from a handshake request
     /**
-     * hybi00 doesn't support subprotocols so there never will be any requested
+     * hybi00 does support subprotocols
+     * https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-00#section-1.9
      *
      * @param [in] req The request to extract from
      * @param [out] subprotocol_list A reference to a vector of strings to store
      * the results in.
      */
-    lib::error_code extract_subprotocols(request_type const &, 
-        std::vector<std::string> &)
+    lib::error_code extract_subprotocols(request_type const & req,
+        std::vector<std::string> & subprotocol_list)
     {
+        if (!req.get_header("Sec-WebSocket-Protocol").empty()) {
+            http::parameter_list p;
+
+             if (!req.get_header_as_plist("Sec-WebSocket-Protocol",p)) {
+                 http::parameter_list::const_iterator it;
+
+                 for (it = p.begin(); it != p.end(); ++it) {
+                     subprotocol_list.push_back(it->first);
+                 }
+             } else {
+                 return error::make_error_code(error::subprotocol_parse_error);
+             }
+        }
         return lib::error_code();
     }
 


### PR DESCRIPTION
This was missing but it is described in the RFC here
https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-00#section-1.9
Found this issue as the websocket client with hixie76 refused the handshake with the missing subprotocol.