### PR TITLE
Fixed memory leaks when stopping io_service::stop (issue #490). 

### DIFF
--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -337,6 +337,19 @@ public:
         return lib::static_pointer_cast<type>(transport_con_type::get_shared());
     }
 
+    /// Callback wrapper that safely locks connection object to avoid memory
+    // leaks.
+    template <typename... Args>
+    static void safe_callback_wrapper(
+        lib::function<void(type*, Args...)> callback,
+        connection_hdl weak_this, Args... args) {
+      if (auto shared_this = weak_this.lock()) {
+        auto bound_callback = lib::bind(
+            callback, static_cast<type*>(shared_this.get()), args...);
+        bound_callback();
+      }
+    }
+
     ///////////////////////////
     // Set Handler Callbacks //
     ///////////////////////////
@@ -1263,7 +1276,6 @@ public:
     void handle_read_http_response(lib::error_code const & ec,
         size_t bytes_transferred);
 
-    
     void handle_write_http_response(lib::error_code const & ec);
     void handle_send_http_request(lib::error_code const & ec);
 

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -142,8 +142,9 @@ lib::error_code connection<config>::send(typename config::message_type::ptr msg)
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 
@@ -187,8 +188,9 @@ void connection<config>::ping(std::string const& payload, lib::error_code& ec) {
             m_ping_timer = transport_con_type::set_timer(
                 m_pong_timeout_dur,
                 lib::bind(
+                    &type::safe_callback_wrapper<std::string, lib::error_code const &>,
                     &type::handle_pong_timeout,
-                    type::get_shared(),
+                    type::get_handle(),
                     payload,
                     lib::placeholders::_1
                 )
@@ -211,8 +213,9 @@ void connection<config>::ping(std::string const& payload, lib::error_code& ec) {
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 
@@ -282,8 +285,9 @@ void connection<config>::pong(std::string const& payload, lib::error_code& ec) {
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 
@@ -341,8 +345,9 @@ lib::error_code connection<config>::interrupt() {
     m_alog.write(log::alevel::devel,"connection connection::interrupt");
     return transport_con_type::interrupt(
         lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::handle_interrupt,
-            type::get_shared()
+            type::get_handle()
         )
     );
 }
@@ -355,18 +360,19 @@ void connection<config>::handle_interrupt() {
     }
 }
 
+/// Pause reading handler. Not safe to call directly
 template <typename config>
 lib::error_code connection<config>::pause_reading() {
     m_alog.write(log::alevel::devel,"connection connection::pause_reading");
     return transport_con_type::dispatch(
         lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::handle_pause_reading,
-            type::get_shared()
+            type::get_handle()
         )
     );
 }
 
-/// Pause reading handler. Not safe to call directly
 template <typename config>
 void connection<config>::handle_pause_reading() {
     m_alog.write(log::alevel::devel,"connection connection::handle_pause_reading");
@@ -378,8 +384,9 @@ lib::error_code connection<config>::resume_reading() {
     m_alog.write(log::alevel::devel,"connection connection::resume_reading");
     return transport_con_type::dispatch(
         lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::handle_resume_reading,
-            type::get_shared()
+            type::get_handle()
         )
     );
 }
@@ -718,8 +725,9 @@ void connection<config>::start() {
     // handle_transport_init from this function.
     transport_con_type::init(
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const &>,
             &type::handle_transport_init,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1
         )
     );
@@ -767,8 +775,9 @@ void connection<config>::read_handshake(size_t num_bytes) {
         m_handshake_timer = transport_con_type::set_timer(
             m_open_handshake_timeout_dur,
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const &>,
                 &type::handle_open_handshake_timeout,
-                type::get_shared(),
+                type::get_handle(),
                 lib::placeholders::_1
             )
         );
@@ -779,8 +788,9 @@ void connection<config>::read_handshake(size_t num_bytes) {
         m_buf,
         config::connection_read_buffer_size,
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const&, size_t>,
             &type::handle_read_handshake,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1,
             lib::placeholders::_2
         )
@@ -916,8 +926,9 @@ void connection<config>::handle_read_handshake(lib::error_code const & ec,
             m_buf,
             config::connection_read_buffer_size,
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const&, size_t>,
                 &type::handle_read_handshake,
-                type::get_shared(),
+                type::get_handle(),
                 lib::placeholders::_1,
                 lib::placeholders::_2
             )
@@ -1316,8 +1327,9 @@ void connection<config>::write_http_response(lib::error_code const & ec) {
         m_handshake_buffer.data(),
         m_handshake_buffer.size(),
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const&>,
             &type::handle_write_http_response,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1
         )
     );
@@ -1447,8 +1459,9 @@ void connection<config>::send_http_request() {
         m_handshake_timer = transport_con_type::set_timer(
             m_open_handshake_timeout_dur,
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const&>,
                 &type::handle_open_handshake_timeout,
-                type::get_shared(),
+                type::get_handle(),
                 lib::placeholders::_1
             )
         );
@@ -1458,8 +1471,9 @@ void connection<config>::send_http_request() {
         m_handshake_buffer.data(),
         m_handshake_buffer.size(),
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const&>,
             &type::handle_send_http_request,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1
         )
     );
@@ -1510,8 +1524,9 @@ void connection<config>::handle_send_http_request(lib::error_code const & ec) {
         m_buf,
         config::connection_read_buffer_size,
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const&, size_t>,
             &type::handle_read_http_response,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1,
             lib::placeholders::_2
         )
@@ -1610,8 +1625,9 @@ void connection<config>::handle_read_http_response(lib::error_code const & ec,
             m_buf,
             config::connection_read_buffer_size,
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const&, size_t>,
                 &type::handle_read_http_response,
-                type::get_shared(),
+                type::get_handle(),
                 lib::placeholders::_1,
                 lib::placeholders::_2
             )
@@ -1696,8 +1712,10 @@ void connection<config>::terminate(lib::error_code const & ec) {
 
     transport_con_type::async_shutdown(
         lib::bind(
+            &type::safe_callback_wrapper
+                <terminate_status, lib::error_code const&>,
             &type::handle_terminate,
-            type::get_shared(),
+            type::get_handle(),
             tstat,
             lib::placeholders::_1
         )
@@ -1878,8 +1896,9 @@ void connection<config>::handle_write_frame(lib::error_code const & ec)
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 }
@@ -2106,8 +2125,9 @@ lib::error_code connection<config>::send_close_frame(close::status::value code,
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 


### PR DESCRIPTION
This fix passes callbacks bound to weak_ptr's instead of shared_ptr's. This binds a helper function that tries to lock the weak_ptr before executing the callback. This is implemented using variadic templates, which are C++11 only. If C++03 compatibility is required, this could be also be implemented using variadic macros.