### PR TITLE
Fixed memory leaks when stopping io_service::stop (issue #490).

### DIFF
--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -343,8 +343,8 @@ public:
     static void safe_callback_wrapper(
         lib::function<void(type*, Args...)> callback,
         connection_hdl weak_this, Args... args) {
-      if (auto shared_this = weak_this.lock()) {
-        auto bound_callback = lib::bind(
+      if (lib::shared_ptr<void> shared_this = weak_this.lock()) {
+        lib::function<void()> bound_callback = lib::bind(
             callback, static_cast<type*>(shared_this.get()), args...);
         bound_callback();
       }

--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -337,6 +337,19 @@ public:
         return lib::static_pointer_cast<type>(transport_con_type::get_shared());
     }
 
+    /// Callback wrapper that safely locks connection object to avoid memory
+    // leaks.
+    template <typename... Args>
+    static void safe_callback_wrapper(
+        lib::function<void(type*, Args...)> callback,
+        connection_hdl weak_this, Args... args) {
+      if (auto shared_this = weak_this.lock()) {
+        auto bound_callback = lib::bind(
+            callback, static_cast<type*>(shared_this.get()), args...);
+        bound_callback();
+      }
+    }
+
     ///////////////////////////
     // Set Handler Callbacks //
     ///////////////////////////

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -143,8 +143,9 @@ lib::error_code connection<config>::send(typename config::message_type::ptr msg)
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 
@@ -188,8 +189,9 @@ void connection<config>::ping(std::string const& payload, lib::error_code& ec) {
             m_ping_timer = transport_con_type::set_timer(
                 m_pong_timeout_dur,
                 lib::bind(
+                    &type::safe_callback_wrapper<std::string, lib::error_code const &>,
                     &type::handle_pong_timeout,
-                    type::get_shared(),
+                    type::get_handle(),
                     payload,
                     lib::placeholders::_1
                 )
@@ -212,8 +214,9 @@ void connection<config>::ping(std::string const& payload, lib::error_code& ec) {
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 
@@ -283,8 +286,9 @@ void connection<config>::pong(std::string const& payload, lib::error_code& ec) {
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 
@@ -342,8 +346,9 @@ lib::error_code connection<config>::interrupt() {
     m_alog.write(log::alevel::devel,"connection connection::interrupt");
     return transport_con_type::interrupt(
         lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::handle_interrupt,
-            type::get_shared()
+            type::get_handle()
         )
     );
 }
@@ -361,8 +366,9 @@ lib::error_code connection<config>::pause_reading() {
     m_alog.write(log::alevel::devel,"connection connection::pause_reading");
     return transport_con_type::dispatch(
         lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::handle_pause_reading,
-            type::get_shared()
+            type::get_handle()
         )
     );
 }
@@ -379,8 +385,9 @@ lib::error_code connection<config>::resume_reading() {
     m_alog.write(log::alevel::devel,"connection connection::resume_reading");
     return transport_con_type::dispatch(
         lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::handle_resume_reading,
-            type::get_shared()
+            type::get_handle()
         )
     );
 }
@@ -729,8 +736,9 @@ void connection<config>::start() {
     // handle_transport_init from this function.
     transport_con_type::init(
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const &>,
             &type::handle_transport_init,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1
         )
     );
@@ -778,8 +786,9 @@ void connection<config>::read_handshake(size_t num_bytes) {
         m_handshake_timer = transport_con_type::set_timer(
             m_open_handshake_timeout_dur,
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const &>,
                 &type::handle_open_handshake_timeout,
-                type::get_shared(),
+                type::get_handle(),
                 lib::placeholders::_1
             )
         );
@@ -790,8 +799,9 @@ void connection<config>::read_handshake(size_t num_bytes) {
         m_buf,
         config::connection_read_buffer_size,
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const&, size_t>,
             &type::handle_read_handshake,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1,
             lib::placeholders::_2
         )
@@ -931,8 +941,9 @@ void connection<config>::handle_read_handshake(lib::error_code const & ec,
             m_buf,
             config::connection_read_buffer_size,
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const&, size_t>,
                 &type::handle_read_handshake,
-                type::get_shared(),
+                type::get_handle(),
                 lib::placeholders::_1,
                 lib::placeholders::_2
             )
@@ -1337,8 +1348,9 @@ void connection<config>::write_http_response(lib::error_code const & ec) {
         m_handshake_buffer.data(),
         m_handshake_buffer.size(),
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const&>,
             &type::handle_write_http_response,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1
         )
     );
@@ -1468,8 +1480,9 @@ void connection<config>::send_http_request() {
         m_handshake_timer = transport_con_type::set_timer(
             m_open_handshake_timeout_dur,
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const&>,
                 &type::handle_open_handshake_timeout,
-                type::get_shared(),
+                type::get_handle(),
                 lib::placeholders::_1
             )
         );
@@ -1479,8 +1492,9 @@ void connection<config>::send_http_request() {
         m_handshake_buffer.data(),
         m_handshake_buffer.size(),
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const&>,
             &type::handle_send_http_request,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1
         )
     );
@@ -1531,8 +1545,9 @@ void connection<config>::handle_send_http_request(lib::error_code const & ec) {
         m_buf,
         config::connection_read_buffer_size,
         lib::bind(
+            &type::safe_callback_wrapper<lib::error_code const&, size_t>,
             &type::handle_read_http_response,
-            type::get_shared(),
+            type::get_handle(),
             lib::placeholders::_1,
             lib::placeholders::_2
         )
@@ -1650,8 +1665,9 @@ void connection<config>::handle_read_http_response(lib::error_code const & ec,
             m_buf,
             config::connection_read_buffer_size,
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const&, size_t>,
                 &type::handle_read_http_response,
-                type::get_shared(),
+                type::get_handle(),
                 lib::placeholders::_1,
                 lib::placeholders::_2
             )
@@ -1736,8 +1752,10 @@ void connection<config>::terminate(lib::error_code const & ec) {
 
     transport_con_type::async_shutdown(
         lib::bind(
+            &type::safe_callback_wrapper
+                <terminate_status, lib::error_code const&>,
             &type::handle_terminate,
-            type::get_shared(),
+            type::get_handle(),
             tstat,
             lib::placeholders::_1
         )
@@ -1918,8 +1936,9 @@ void connection<config>::handle_write_frame(lib::error_code const & ec)
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 }
@@ -2146,8 +2165,9 @@ lib::error_code connection<config>::send_close_frame(close::status::value code,
 
     if (needs_writing) {
         transport_con_type::dispatch(lib::bind(
+            &type::safe_callback_wrapper<>,
             &type::write_frame,
-            type::get_shared()
+            type::get_handle()
         ));
     }
 

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -296,6 +296,19 @@ public:
         return m_connection_hdl;
     }
 
+    /// Callback wrapper that safely locks connection object to avoid memory
+    // leaks.
+    template <typename... Args>
+    static void safe_callback_wrapper(
+        lib::function<void(type*, Args...)> callback,
+        connection_hdl weak_this, Args... args) {
+      if (auto shared_this = weak_this.lock()) {
+        auto bound_callback = lib::bind(
+            callback, static_cast<type*>(shared_this.get()), args...);
+        bound_callback();
+      }
+    }
+
     /// Call back a function after a period of time.
     /**
      * Sets a timer that calls back a function after the specified period of
@@ -318,14 +331,18 @@ public:
 
         if (config::enable_multithreading) {
             new_timer->async_wait(m_strand->wrap(lib::bind(
-                &type::handle_timer, get_shared(),
+                &type::safe_callback_wrapper<
+                    timer_ptr, timer_handler, lib::asio::error_code const&>,
+                &type::handle_timer, get_handle(),
                 new_timer,
                 callback,
                 lib::placeholders::_1
             )));
         } else {
             new_timer->async_wait(lib::bind(
-                &type::handle_timer, get_shared(),
+                &type::safe_callback_wrapper<
+                    timer_ptr, timer_handler, lib::asio::error_code const&>,
+                &type::handle_timer, get_handle(),
                 new_timer,
                 callback,
                 lib::placeholders::_1
@@ -419,8 +436,9 @@ protected:
 
         socket_con_type::pre_init(
             lib::bind(
+                &type::safe_callback_wrapper<lib::error_code const &>,
                 &type::handle_pre_init,
-                get_shared(),
+                get_handle(),
                 lib::placeholders::_1
             )
         );
@@ -465,11 +483,17 @@ protected:
             m_strand = lib::make_shared<lib::asio::io_service::strand>(
                 lib::ref(*io_service));
         }
-        m_async_read_handler = lib::bind(&type::handle_async_read,
-            get_shared(), lib::placeholders::_1, lib::placeholders::_2);
+        m_async_read_handler = lib::bind(
+            &type::safe_callback_wrapper<
+                lib::asio::error_code const&, size_t>,
+            &type::handle_async_read,
+            get_handle(), lib::placeholders::_1, lib::placeholders::_2);
 
-        m_async_write_handler = lib::bind(&type::handle_async_write,
-            get_shared(), lib::placeholders::_1, lib::placeholders::_2);
+        m_async_write_handler = lib::bind(
+            &type::safe_callback_wrapper<
+                lib::asio::error_code const&, size_t>,
+            &type::handle_async_write,
+            get_handle(), lib::placeholders::_1, lib::placeholders::_2);
 
         lib::error_code ec = socket_con_type::init_asio(io_service, m_strand,
             m_is_server);
@@ -517,8 +541,10 @@ protected:
             post_timer = set_timer(
                 config::timeout_socket_post_init,
                 lib::bind(
+                    &type::safe_callback_wrapper<
+                        timer_ptr, init_handler, lib::error_code const &>,
                     &type::handle_post_init_timeout,
-                    get_shared(),
+                    get_handle(),
                     post_timer,
                     m_init_handler,
                     lib::placeholders::_1
@@ -528,8 +554,10 @@ protected:
 
         socket_con_type::post_init(
             lib::bind(
+                &type::safe_callback_wrapper<
+                    timer_ptr, init_handler, lib::error_code const &>,
                 &type::handle_post_init,
-                get_shared(),
+                get_handle(),
                 post_timer,
                 m_init_handler,
                 lib::placeholders::_1
@@ -630,8 +658,10 @@ protected:
         m_proxy_data->timer = this->set_timer(
             m_proxy_data->timeout_proxy,
             lib::bind(
+                &type::safe_callback_wrapper<
+                    init_handler, lib::error_code const &>,
                 &type::handle_proxy_timeout,
-                get_shared(),
+                get_handle(),
                 m_init_handler,
                 lib::placeholders::_1
             )
@@ -643,7 +673,9 @@ protected:
                 socket_con_type::get_next_layer(),
                 m_bufs,
                 m_strand->wrap(lib::bind(
-                    &type::handle_proxy_write, get_shared(),
+                    &type::safe_callback_wrapper<
+                        init_handler, lib::asio::error_code const &>,
+                    &type::handle_proxy_write, get_handle(),
                     m_init_handler,
                     lib::placeholders::_1
                 ))
@@ -653,7 +685,9 @@ protected:
                 socket_con_type::get_next_layer(),
                 m_bufs,
                 lib::bind(
-                    &type::handle_proxy_write, get_shared(),
+                    &type::safe_callback_wrapper<
+                        init_handler, lib::asio::error_code const &>,
+                    &type::handle_proxy_write, get_handle(),
                     m_init_handler,
                     lib::placeholders::_1
                 )
@@ -727,7 +761,9 @@ protected:
                 m_proxy_data->read_buf,
                 "\r\n\r\n",
                 m_strand->wrap(lib::bind(
-                    &type::handle_proxy_read, get_shared(),
+                    &type::safe_callback_wrapper<
+                        init_handler, lib::asio::error_code const&, size_t>,
+                    &type::handle_proxy_read, get_handle(),
                     callback,
                     lib::placeholders::_1, lib::placeholders::_2
                 ))
@@ -738,7 +774,9 @@ protected:
                 m_proxy_data->read_buf,
                 "\r\n\r\n",
                 lib::bind(
-                    &type::handle_proxy_read, get_shared(),
+                    &type::safe_callback_wrapper<
+                        init_handler, lib::asio::error_code const&, size_t>,
+                    &type::handle_proxy_read, get_handle(),
                     callback,
                     lib::placeholders::_1, lib::placeholders::_2
                 )
@@ -1078,8 +1116,10 @@ protected:
         shutdown_timer = set_timer(
             config::timeout_socket_shutdown,
             lib::bind(
+                &type::safe_callback_wrapper<
+                    timer_ptr, init_handler, lib::error_code const &>,
                 &type::handle_async_shutdown_timeout,
-                get_shared(),
+                get_handle(),
                 shutdown_timer,
                 callback,
                 lib::placeholders::_1
@@ -1088,8 +1128,11 @@ protected:
 
         socket_con_type::async_shutdown(
             lib::bind(
+                &type::safe_callback_wrapper<
+                    timer_ptr, shutdown_handler,
+                    lib::asio::error_code const &>,
                 &type::handle_async_shutdown,
-                get_shared(),
+                get_handle(),
                 shutdown_timer,
                 callback,
                 lib::placeholders::_1


### PR DESCRIPTION
This fix passes callbacks bound to weak_ptr's instead of shared_ptr's. This binds a helper function that tries to lock the weak_ptr before executing the callback. This is implemented using variadic templates, which are C++11 only. If C++03 compatibility is required, this could be also be implemented using variadic macros.
