### PR TITLE
Pluggable Authenticated Proxy Support #520

### DIFF
--- a/examples/scratch_server/scratch_server.cpp
+++ b/examples/scratch_server/scratch_server.cpp
@@ -28,6 +28,8 @@ struct deflate_config : public websocketpp::config::debug_core {
     
     typedef base::rng_type rng_type;
     
+    typedef type::proxy_authenticator_type proxy_authenticator_type;
+    
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -36,6 +38,7 @@ struct deflate_config : public websocketpp::config::debug_core {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint 
             socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config> 

--- a/test/connection/connection.cpp
+++ b/test/connection/connection.cpp
@@ -99,6 +99,8 @@ struct debug_config_client : public websocketpp::config::core {
     typedef core::elog_type elog_type;
 
     typedef websocketpp::random::none::int_generator<uint32_t> rng_type;
+    
+    typedef core::proxy_authenticator_type proxy_authenticator_type;
 
     struct transport_config {
         typedef type::concurrency_type concurrency_type;
@@ -106,7 +108,8 @@ struct debug_config_client : public websocketpp::config::core {
         typedef type::alog_type alog_type;
         typedef type::request_type request_type;
         typedef type::response_type response_type;
-
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
+        
         /// Controls compile time enabling/disabling of thread syncronization
         /// code Disabling can provide a minor performance improvement to single
         /// threaded applications

--- a/test/http/proxy_authenticator.cpp
+++ b/test/http/proxy_authenticator.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(auth_scheme_parser) {
     // Valid Basic Auth - with quoted string
     std::string auth_headers = "Basic realm=\"some realm with \\\"quoted string\\\"\",type=1";
 
-    auto auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+    websocketpp::http::proxy::auth_parser::AuthSchemes auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
 
     BOOST_CHECK(auth_schemes.size() == 1);
     BOOST_CHECK(auth_schemes.front().is_basic());
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(auth_scheme_parser) {
     BOOST_CHECK(auth_schemes[1].is_ntlm());
     BOOST_CHECK(auth_schemes[1].get_challenge().empty());
 
-    auto auth_scheme = websocketpp::http::proxy::auth_parser::select_auth_scheme(auth_headers);
+    websocketpp::http::proxy::auth_parser::AuthScheme auth_scheme = websocketpp::http::proxy::auth_parser::select_auth_scheme(auth_headers);
 
     BOOST_CHECK(auth_scheme.is_ntlm());
     BOOST_CHECK(auth_scheme.get_challenge().empty());
@@ -137,7 +137,7 @@ public:
     static ReportContext report_context;
 
     static fake_security_context::Ptr build(const std::string& proxyName, const std::string& authScheme) {
-        auto context = websocketpp::lib::make_shared<fake_security_context>(proxyName, authScheme);
+        fake_security_context::Ptr context = websocketpp::lib::make_shared<fake_security_context>(proxyName, authScheme);
 
         if (report_context) {
             report_context(context);

--- a/test/http/proxy_authenticator.cpp
+++ b/test/http/proxy_authenticator.cpp
@@ -1,0 +1,245 @@
+#define BOOST_TEST_MODULE http_authenticator
+#include <boost/test/unit_test.hpp>
+
+#include <iostream>
+#include <string>
+
+#include <websocketpp/http/proxy_authenticator.hpp>
+
+BOOST_AUTO_TEST_CASE(is_token68_char) {
+    for (int i = 0x00; i <= 0xFF; i++)
+    {
+        bool expectedResult = false;
+
+        expectedResult = ::isalnum(i) ? true : expectedResult;
+
+        expectedResult = (i == '-') ? true : expectedResult;
+        expectedResult = (i == '.') ? true : expectedResult;
+        expectedResult = (i == '_') ? true : expectedResult;
+        expectedResult = (i == '~') ? true : expectedResult;
+        expectedResult = (i == '+') ? true : expectedResult;
+        expectedResult = (i == '/') ? true : expectedResult;
+        expectedResult = (i == '=') ? true : expectedResult;
+
+        BOOST_CHECK(websocketpp::http::proxy::auth_parser::is_token68_char((unsigned char)(i)) == expectedResult);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(auth_scheme_parser) {
+    // Valid Basic Auth - with quoted string
+    std::string auth_headers = "Basic realm=\"some realm with \\\"quoted string\\\"\",type=1";
+
+    auto auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 1);
+    BOOST_CHECK(auth_schemes.front().is_basic());
+    BOOST_CHECK(auth_schemes.front().get_realm() == "some realm with \"quoted string\"");
+
+    // NTLM
+    auth_headers = "NTLM";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 1);
+    BOOST_CHECK(auth_schemes.front().is_ntlm());
+    BOOST_CHECK(auth_schemes.front().get_challenge().empty());
+
+    // NTLM with Challenge
+    auth_headers = "NTLM challengeString=";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 1);
+    BOOST_CHECK(auth_schemes.front().is_ntlm());
+    BOOST_CHECK(auth_schemes.front().get_challenge() == "challengeString=");
+
+    // Negotiate with Challenge
+    auth_headers = "neGotiate challengeString=";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 1);
+    BOOST_CHECK(auth_schemes.front().is_negotiate());
+    BOOST_CHECK(auth_schemes.front().get_challenge() == "challengeString=");
+
+    // Valid Basic Auth + NTLM (mixed case)
+    auth_headers = "baSic realm=\"some realm\",type=1,nTlm";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 2);
+    BOOST_CHECK(auth_schemes[0].is_basic());
+    BOOST_CHECK(auth_schemes[0].get_realm() == "some realm");
+    BOOST_CHECK(auth_schemes[1].is_ntlm());
+    BOOST_CHECK(auth_schemes[1].get_challenge().empty());
+
+    auto auth_scheme = websocketpp::http::proxy::auth_parser::select_auth_scheme(auth_headers);
+
+    BOOST_CHECK(auth_scheme.is_ntlm());
+    BOOST_CHECK(auth_scheme.get_challenge().empty());
+
+    // Digest + NTLM + Basic
+    auth_headers = "Digest, NTLM, baSic realm=\"some realm\",type=1";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 3);
+    BOOST_CHECK(auth_schemes[0].is_digest());
+    BOOST_CHECK(auth_schemes[1].is_ntlm());
+    BOOST_CHECK(auth_schemes[1].get_challenge().empty());
+    BOOST_CHECK(auth_schemes[2].is_basic());
+    BOOST_CHECK(auth_schemes[2].get_realm() == "some realm");
+
+    auth_scheme = websocketpp::http::proxy::auth_parser::select_auth_scheme(auth_headers);
+
+    BOOST_CHECK(auth_scheme.is_ntlm());
+    BOOST_CHECK(auth_scheme.get_challenge().empty());
+
+    // Digest + NTLM + Basic + Negotiate
+    auth_headers = "Digest, NTLM, baSic realm=\"some realm\",type=1, negotiate";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 4);
+    BOOST_CHECK(auth_schemes[0].is_digest());
+    BOOST_CHECK(auth_schemes[1].is_ntlm());
+    BOOST_CHECK(auth_schemes[1].get_challenge().empty());
+    BOOST_CHECK(auth_schemes[2].is_basic());
+    BOOST_CHECK(auth_schemes[2].get_realm() == "some realm");
+    BOOST_CHECK(auth_schemes[3].is_negotiate());
+    BOOST_CHECK(auth_schemes[3].get_challenge().empty());
+
+    auth_scheme = websocketpp::http::proxy::auth_parser::select_auth_scheme(auth_headers);
+
+    BOOST_CHECK(auth_scheme.is_negotiate());
+    BOOST_CHECK(auth_scheme.get_challenge().empty());
+
+    // Unknown Auth Scheme fails the parse for all schemes
+    auth_headers = "Digest, NTLM, Basic realm=\"some realm\",type=1, NegotiateX";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.empty());
+
+    // Empty Parameter value for a basic auth fails the parse
+    auth_headers = "Digest, NTLM, Basic realm=\"some realm\",type=, Negotiate";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.empty());
+}
+
+class fake_security_context {
+public:
+    typedef websocketpp::lib::shared_ptr<fake_security_context> Ptr;
+    typedef std::function<void(Ptr)> ReportContext;
+
+    static ReportContext report_context;
+
+    static fake_security_context::Ptr build(const std::string& proxyName, const std::string& authScheme) {
+        auto context = websocketpp::lib::make_shared<fake_security_context>(proxyName, authScheme);
+
+        if (report_context) {
+            report_context(context);
+        }
+
+        return context;
+    }
+
+    fake_security_context(const std::string& proxyName, const std::string& authScheme) {
+    }
+
+    bool nextAuthToken(const std::string& challenge) {
+        m_last_challenge = challenge;
+        return m_auth_token.empty() ? false : true;
+    }
+
+    std::string getUpdatedToken() const {
+        return m_auth_token;
+    }
+
+    std::string m_auth_token;
+    std::string m_last_challenge;
+};
+
+fake_security_context::ReportContext fake_security_context::report_context;
+
+BOOST_AUTO_TEST_CASE(proxy_authenticator_tests) {
+    //
+    // Setup interceptor to access the security_context object
+    //
+    std::string proxy_name("myProxy.com");
+
+    fake_security_context::Ptr security_context;
+    fake_security_context::report_context = [&security_context](fake_security_context::Ptr newContext) {
+        security_context = newContext;
+        newContext->m_auth_token = "Token1=";
+    };
+
+    // 
+    // Test an typical NTLM multi step challenge auth flow
+    //
+    {
+        security_context.reset();
+
+        websocketpp::http::proxy::proxy_authenticator<fake_security_context> proxy_authenticator(proxy_name);
+
+        BOOST_CHECK(!security_context);
+
+        BOOST_CHECK(proxy_authenticator.get_auth_token().empty());
+
+        std::string auth_headers = "NTLM challenge1=";
+
+        BOOST_CHECK(proxy_authenticator.next_token(auth_headers));
+        BOOST_CHECK(security_context);
+        BOOST_CHECK(security_context->m_last_challenge == "challenge1=");
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NTLM Token1=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token().empty());
+
+        security_context->m_auth_token = "Token2=";
+        auth_headers = "NTLM challenge2=";
+
+        BOOST_CHECK(proxy_authenticator.next_token(auth_headers));
+        BOOST_CHECK(security_context->m_last_challenge == "challenge2=");
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NTLM Token2=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token().empty());
+
+        proxy_authenticator.set_authenticated();
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NTLM Token2=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token() == "NTLM Token2=");
+    }
+
+    // 
+    // Negotiate Flow (same as NTLM, but we're checking case insensitive)
+    //
+    {
+        security_context.reset();
+
+        websocketpp::http::proxy::proxy_authenticator<fake_security_context> proxy_authenticator(proxy_name);
+
+        BOOST_CHECK(!security_context);
+
+        BOOST_CHECK(proxy_authenticator.get_auth_token().empty());
+
+        std::string auth_headers = "NeGoTiAtE challenge1=";
+
+        BOOST_CHECK(proxy_authenticator.next_token(auth_headers));
+        BOOST_CHECK(security_context);
+        BOOST_CHECK(security_context->m_last_challenge == "challenge1=");
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NeGoTiAtE Token1=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token().empty());
+
+        security_context->m_auth_token = "Token2=";
+        auth_headers = "Negotiate challenge2=";
+
+        BOOST_CHECK(proxy_authenticator.next_token(auth_headers));
+        BOOST_CHECK(security_context->m_last_challenge == "challenge2=");
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NeGoTiAtE Token2=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token().empty());
+
+        proxy_authenticator.set_authenticated();
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NeGoTiAtE Token2=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token() == "NeGoTiAtE Token2=");
+    }
+}
+

--- a/test/transport/asio/timers.cpp
+++ b/test/transport/asio/timers.cpp
@@ -47,6 +47,10 @@
 #include <websocketpp/logger/stub.hpp>
 //#include <websocketpp/logger/basic.hpp>
 
+// Proxy Authentication
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 #include <boost/asio.hpp>
 
 // Accept a connection, read data, and discard until EOF
@@ -94,6 +98,9 @@ struct config {
     typedef websocketpp::http::parser::request request_type;
     typedef websocketpp::http::parser::response response_type;
     typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+    
+    typedef websocketpp::lib::security::SecurityContext security_context;
+    typedef http::proxy::proxy_authenticator<security_context> proxy_authenticator_type;    
 
     static const bool enable_multithreading = true;
 

--- a/test/transport/asio/timers.cpp
+++ b/test/transport/asio/timers.cpp
@@ -100,7 +100,7 @@ struct config {
     typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
     
     typedef websocketpp::lib::security::SecurityContext security_context;
-    typedef http::proxy::proxy_authenticator<security_context> proxy_authenticator_type;    
+    typedef websocketpp::http::proxy::proxy_authenticator<security_context> proxy_authenticator_type;    
 
     static const bool enable_multithreading = true;
 

--- a/test/transport/iostream/connection.cpp
+++ b/test/transport/iostream/connection.cpp
@@ -41,12 +41,19 @@
 #include <websocketpp/concurrency/basic.hpp>
 #include <websocketpp/logger/basic.hpp>
 
+// Proxy Authentication Policy
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 struct config {
     typedef websocketpp::concurrency::basic concurrency_type;
     typedef websocketpp::log::basic<concurrency_type,
         websocketpp::log::elevel> elog_type;
     typedef websocketpp::log::basic<concurrency_type,
         websocketpp::log::alevel> alog_type;
+        
+    typedef websocketpp::lib::security::SecurityContext security_context;
+    typedef websocketpp::http::proxy::proxy_authenticator<security_context> proxy_authenticator_type;            
 };
 
 typedef websocketpp::transport::iostream::connection<config> iostream_con;

--- a/websocketpp/common/impl/security_context.hpp
+++ b/websocketpp/common/impl/security_context.hpp
@@ -1,0 +1,200 @@
+/*
+* Copyright (c) 2016, Peter Thorson. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the WebSocket++ Project nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The initial version of this Security Context policy was contributed to the WebSocket++
+* project by Colie McGarry.
+*/
+
+#ifndef WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
+#define WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
+
+#if defined(_WIN32)
+
+#include <websocketpp/base64/base64.hpp>
+
+#define SECURITY_WIN32
+
+#include <sspi.h>
+
+#define SEC_SUCCESS(Status) ((Status) >= 0)
+
+#pragma comment(lib, "Secur32.lib")
+
+namespace websocketpp {
+    namespace lib {
+        namespace security {
+            namespace platform {
+                class SecurityContext
+                {
+                public:
+                    using Ptr = std::shared_ptr<SecurityContext>;
+
+                    static SecurityContext::Ptr build(const std::string& proxyName, const std::string& authScheme) {
+                        return  lib::make_shared<SecurityContext>(proxyName, authScheme);
+                    }
+
+                    SecurityContext(const std::string& proxyName, const std::string& authScheme) :
+                        proxyName(proxyName), authScheme(authScheme)
+                    {
+                        TimeStamp           Lifetime;
+                        SECURITY_STATUS     ss;
+
+                        ss = ::AcquireCredentialsHandleA(
+                            NULL,
+                            (SEC_CHAR *)authScheme.c_str(),
+                            SECPKG_CRED_OUTBOUND,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL,
+                            &hCred,
+                            &Lifetime);
+
+                        if (!(SEC_SUCCESS(ss)))
+                        {
+                            return;
+                        }
+
+                        freeCredentials = true;
+                    }
+                    ~SecurityContext()
+                    {
+                        if (freeCredentials) {
+                            ::FreeCredentialsHandle(&hCred);
+                        }
+                    }
+
+                    bool nextAuthToken(const std::string& challenge)
+                    {
+                        TimeStamp           Lifetime;
+                        SECURITY_STATUS     ss;
+                        SecBufferDesc       OutBuffDesc;
+                        SecBuffer           OutSecBuff;
+                        ULONG               ContextAttributes;
+
+                        OutBuffDesc.ulVersion = SECBUFFER_VERSION;
+                        OutBuffDesc.cBuffers = 1;
+                        OutBuffDesc.pBuffers = &OutSecBuff;
+
+                        OutSecBuff.cbBuffer = 0;
+                        OutSecBuff.BufferType = SECBUFFER_TOKEN;
+                        OutSecBuff.pvBuffer = 0;
+
+                        std::string target;
+
+                        if (authScheme == "Negotiate")
+                            target = "http/" + proxyName; // Service Principle Name
+
+                        if (challenge.empty())
+                        {
+                            ss = ::InitializeSecurityContextA(
+                                &hCred,
+                                NULL,
+                                (SEC_CHAR *)target.c_str(), //.c_str(), // pszTarget,
+                                ISC_REQ_ALLOCATE_MEMORY, //ISC_REQ_CONFIDENTIALITY ,
+                                0,
+                                SECURITY_NETWORK_DREP, //SECURITY_NATIVE_DREP,
+                                NULL,
+                                0,
+                                &hContext,
+                                &OutBuffDesc,
+                                &ContextAttributes,
+                                &Lifetime);
+                        }
+                        else
+                        {
+                            auto decodedChallenge = base64_decode(challenge);
+
+                            SecBufferDesc     InBuffDesc;
+                            SecBuffer         InSecBuff;
+
+                            InBuffDesc.ulVersion = 0;
+                            InBuffDesc.cBuffers = 1;
+                            InBuffDesc.pBuffers = &InSecBuff;
+
+                            InSecBuff.cbBuffer = (unsigned long)decodedChallenge.size();
+                            InSecBuff.BufferType = SECBUFFER_TOKEN;
+                            InSecBuff.pvBuffer = (BYTE *)&decodedChallenge[0];
+
+                            ss = ::InitializeSecurityContextA(
+                                &hCred,
+                                &hContext,
+                                (SEC_CHAR *)target.c_str(),
+                                ISC_REQ_ALLOCATE_MEMORY, //ISC_REQ_CONFIDENTIALITY ,
+                                0,
+                                SECURITY_NETWORK_DREP, // SECURITY_NATIVE_DREP,
+                                &InBuffDesc,
+                                0,
+                                &hContext,
+                                &OutBuffDesc,
+                                &ContextAttributes,
+                                &Lifetime);
+                        }
+
+                        if ((SEC_I_COMPLETE_NEEDED == ss) || (SEC_I_COMPLETE_AND_CONTINUE == ss))
+                        {
+                            ss = ::CompleteAuthToken(&hContext, &OutBuffDesc);
+
+                            if (!SEC_SUCCESS(ss))
+                            {
+                                return false;
+                            }
+                        }
+
+                        if (!OutSecBuff.pvBuffer)
+                        {
+                            return false;
+                        }
+
+                        updatedToken = base64_encode((const unsigned char*)OutSecBuff.pvBuffer, (size_t)OutSecBuff.cbBuffer);
+
+                        ::FreeContextBuffer(OutSecBuff.pvBuffer);
+
+                        bool continueAuthFlow = ((SEC_I_CONTINUE_NEEDED == ss) || (SEC_I_COMPLETE_AND_CONTINUE == ss));
+
+                        return continueAuthFlow;
+                    }
+
+                    std::string getUpdatedToken() const
+                    {
+                        return updatedToken;
+                    }
+
+                private:
+                    SecHandle         hContext;
+                    CredHandle        hCred;
+                    std::string       proxyName;
+                    std::string       authScheme;
+                    std::string       updatedToken;
+
+                    bool              freeCredentials = false;
+                };
+            }
+        }       // security
+    }           // lib
+}               // websocket
+
+#endif // WIN32
+#endif // WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP

--- a/websocketpp/common/impl/security_context.hpp
+++ b/websocketpp/common/impl/security_context.hpp
@@ -49,7 +49,7 @@ namespace websocketpp {
                 class SecurityContext
                 {
                 public:
-                    using Ptr = std::shared_ptr<SecurityContext>;
+                    typedef std::shared_ptr<SecurityContext> Ptr;
 
                     static SecurityContext::Ptr build(const std::string& proxyName, const std::string& authScheme) {
                         return  lib::make_shared<SecurityContext>(proxyName, authScheme);

--- a/websocketpp/common/impl/security_context.hpp
+++ b/websocketpp/common/impl/security_context.hpp
@@ -30,7 +30,7 @@
 #ifndef WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
 #define WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
 
-#if defined(_WIN32)
+#ifdef _WIN32
 
 #include <websocketpp/base64/base64.hpp>
 
@@ -191,6 +191,29 @@ namespace websocketpp {
 
                     bool              freeCredentials = false;
                 };
+            }
+        }       // security
+    }           // lib
+}               // websocket
+
+#else // _WIN32
+
+namespace websocketpp {
+    namespace lib {
+        namespace security {
+            namespace platform {
+                class SecurityContext
+                {
+                public:
+                    typedef std::shared_ptr<SecurityContext> Ptr;
+
+                    static Ptr build(const std::string& , const std::string& )  { return  Ptr(); }
+
+                    SecurityContext(const std::string& , const std::string& )   { }
+
+                    bool nextAuthToken(const std::string&)                      { return ""; }
+                    std::string getUpdatedToken() const                         { return ""; }
+               };
             }
         }       // security
     }           // lib

--- a/websocketpp/common/impl/security_context.hpp
+++ b/websocketpp/common/impl/security_context.hpp
@@ -30,6 +30,8 @@
 #ifndef WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
 #define WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
 
+#include <websocketpp/common/memory.hpp>
+
 #ifdef _WIN32
 
 #include <websocketpp/base64/base64.hpp>
@@ -49,7 +51,7 @@ namespace websocketpp {
                 class SecurityContext
                 {
                 public:
-                    typedef std::shared_ptr<SecurityContext> Ptr;
+                    typedef lib::shared_ptr<SecurityContext> Ptr;
 
                     static SecurityContext::Ptr build(const std::string& proxyName, const std::string& authScheme) {
                         return  lib::make_shared<SecurityContext>(proxyName, authScheme);
@@ -205,7 +207,7 @@ namespace websocketpp {
                 class SecurityContext
                 {
                 public:
-                    typedef std::shared_ptr<SecurityContext> Ptr;
+                    typedef lib::shared_ptr<SecurityContext> Ptr;
 
                     static Ptr build(const std::string& , const std::string& )  { return  Ptr(); }
 

--- a/websocketpp/common/security_context.hpp
+++ b/websocketpp/common/security_context.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, Peter Thorson. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the WebSocket++ Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The initial version of this Security Context policy was contributed to the WebSocket++
+ * project by Colie McGarry.
+ */
+
+#ifndef WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP
+#define WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP
+
+namespace websocketpp {
+    namespace lib {
+        namespace security {
+            class SecurityContext
+            {
+            public:
+                using Ptr = std::shared_ptr<SecurityContext>;
+
+                static Ptr build(const std::string& , const std::string& )  { return  Ptr(); }
+
+                SecurityContext(const std::string& , const std::string& )   { }
+
+                bool nextAuthToken(const std::string&)                      { return ""; }
+                std::string getUpdatedToken() const                         { return ""; }
+            };
+        }       // security
+    }           // lib
+}               // websocket
+
+#endif // WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP

--- a/websocketpp/common/security_context.hpp
+++ b/websocketpp/common/security_context.hpp
@@ -38,7 +38,7 @@ namespace websocketpp {
             class SecurityContext
             {
             public:
-                typedef std::shared_ptr<SecurityContext> Ptr;
+                typedef lib::shared_ptr<SecurityContext> Ptr;
 
                 static Ptr build(const std::string& , const std::string& )  { return  Ptr(); }
 

--- a/websocketpp/common/security_context.hpp
+++ b/websocketpp/common/security_context.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Peter Thorson. All rights reserved.
+ * Copyright (c) 2014, Peter Thorson. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -23,8 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * The initial version of this Security Context policy was contributed to the WebSocket++
- * project by Colie McGarry.
  */
 
 #ifndef WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP
@@ -36,7 +34,7 @@ namespace websocketpp {
             class SecurityContext
             {
             public:
-                using Ptr = std::shared_ptr<SecurityContext>;
+                typedef std::shared_ptr<SecurityContext> Ptr;
 
                 static Ptr build(const std::string& , const std::string& )  { return  Ptr(); }
 

--- a/websocketpp/common/security_context.hpp
+++ b/websocketpp/common/security_context.hpp
@@ -28,6 +28,10 @@
 #ifndef WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP
 #define WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP
 
+#include <websocketpp/common/memory.hpp>
+
+#include <string>
+
 namespace websocketpp {
     namespace lib {
         namespace security {

--- a/websocketpp/config/asio.hpp
+++ b/websocketpp/config/asio.hpp
@@ -58,6 +58,8 @@ struct asio_tls : public core {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -65,6 +67,7 @@ struct asio_tls : public core {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/asio_client.hpp
+++ b/websocketpp/config/asio_client.hpp
@@ -58,6 +58,8 @@ struct asio_tls_client : public core_client {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -65,6 +67,7 @@ struct asio_tls_client : public core_client {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/asio_client_authenticated_proxy.hpp
+++ b/websocketpp/config/asio_client_authenticated_proxy.hpp
@@ -1,0 +1,85 @@
+/*
+* Copyright (c) 2016, Peter Thorson. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the WebSocket++ Project nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The initial version of this Security Context policy was contributed to the WebSocket++
+* project by Colie McGarry.
+*/
+
+#ifndef WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_HPP
+#define WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_HPP
+
+#include <websocketpp/config/core_client.hpp>
+#include <websocketpp/transport/asio/endpoint.hpp>
+#include <websocketpp/transport/asio/security/tls.hpp>
+
+// Pull in non-tls config
+#include <websocketpp/config/asio_no_tls_client.hpp>
+
+#include <websocketpp/http/proxy_authenticator.hpp>
+#include <websocketpp/common/impl/security_context.hpp>
+
+// Define TLS config
+namespace websocketpp {
+namespace config {
+
+/// Client config with asio transport and TLS enabled
+struct asio_tls_client_authenticated_proxy : public core_client {
+    typedef asio_tls_client_authenticated_proxy type;
+    typedef core_client base;
+
+    typedef base::concurrency_type concurrency_type;
+
+    typedef base::request_type request_type;
+    typedef base::response_type response_type;
+
+    typedef base::message_type message_type;
+    typedef base::con_msg_manager_type con_msg_manager_type;
+    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
+
+    typedef base::alog_type alog_type;
+    typedef base::elog_type elog_type;
+
+    typedef base::rng_type rng_type;
+
+    typedef websocketpp::http::proxy::proxy_authenticator<websocketpp::lib::security::platform::SecurityContext> proxy_authenticator_type;
+
+    struct transport_config : public base::transport_config {
+        typedef type::concurrency_type concurrency_type;
+        typedef type::alog_type alog_type;
+        typedef type::elog_type elog_type;
+        typedef type::request_type request_type;
+        typedef type::response_type response_type;
+        typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
+    };
+
+    typedef websocketpp::transport::asio::endpoint<transport_config>
+        transport_type;
+};
+
+} // namespace config
+} // namespace websocketpp
+
+#endif // WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_HPP

--- a/websocketpp/config/asio_client_authenticated_proxy.hpp
+++ b/websocketpp/config/asio_client_authenticated_proxy.hpp
@@ -27,8 +27,8 @@
 * project by Colie McGarry.
 */
 
-#ifndef WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_HPP
-#define WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_HPP
+#ifndef WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_PROXY_AUTHENTICATED_HPP
+#define WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_PROXY_AUTHENTICATED_HPP
 
 #include <websocketpp/config/core_client.hpp>
 #include <websocketpp/transport/asio/endpoint.hpp>

--- a/websocketpp/config/asio_no_tls.hpp
+++ b/websocketpp/config/asio_no_tls.hpp
@@ -53,6 +53,8 @@ struct asio : public core {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -61,6 +63,7 @@ struct asio : public core {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;            
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/asio_no_tls_client.hpp
+++ b/websocketpp/config/asio_no_tls_client.hpp
@@ -53,6 +53,8 @@ struct asio_client : public core_client {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -61,6 +63,7 @@ struct asio_client : public core_client {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/core.hpp
+++ b/websocketpp/config/core.hpp
@@ -110,6 +110,7 @@ struct core {
         typedef type::alog_type alog_type;
         typedef type::request_type request_type;
         typedef type::response_type response_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
 
         /// Controls compile time enabling/disabling of thread syncronization
         /// code Disabling can provide a minor performance improvement to single

--- a/websocketpp/config/core.hpp
+++ b/websocketpp/config/core.hpp
@@ -43,6 +43,10 @@
 #include <websocketpp/http/request.hpp>
 #include <websocketpp/http/response.hpp>
 
+// Proxy Authentication
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 // Messages
 #include <websocketpp/message_buffer/message.hpp>
 #include <websocketpp/message_buffer/alloc.hpp>
@@ -90,6 +94,10 @@ struct core {
 
     /// RNG policies
     typedef websocketpp::random::none::int_generator<uint32_t> rng_type;
+    
+    /// Proxy Authenticator policy
+    typedef websocketpp::lib::security::SecurityContext security_context;
+    typedef http::proxy::proxy_authenticator<security_context> proxy_authenticator_type;    
 
     /// Controls compile time enabling/disabling of thread syncronization
     /// code Disabling can provide a minor performance improvement to single

--- a/websocketpp/config/core_client.hpp
+++ b/websocketpp/config/core_client.hpp
@@ -47,6 +47,10 @@
 #include <websocketpp/http/request.hpp>
 #include <websocketpp/http/response.hpp>
 
+// Proxy Authentication
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 // Messages
 #include <websocketpp/message_buffer/message.hpp>
 #include <websocketpp/message_buffer/alloc.hpp>
@@ -99,6 +103,9 @@ struct core_client {
     /// RNG policies
     typedef websocketpp::random::random_device::int_generator<uint32_t,
         concurrency_type> rng_type;
+
+    typedef websocketpp::lib::security::SecurityContext security_context;
+    typedef http::proxy::proxy_authenticator<security_context> proxy_authenticator_type;
 
     /// Controls compile time enabling/disabling of thread syncronization code
     /// Disabling can provide a minor performance improvement to single threaded

--- a/websocketpp/config/debug.hpp
+++ b/websocketpp/config/debug.hpp
@@ -44,6 +44,10 @@
 #include <websocketpp/http/request.hpp>
 #include <websocketpp/http/response.hpp>
 
+// Proxy Authentication
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 // Messages
 #include <websocketpp/message_buffer/message.hpp>
 #include <websocketpp/message_buffer/alloc.hpp>
@@ -91,10 +95,12 @@ struct debug_core {
 
     /// RNG policies
     typedef websocketpp::random::none::int_generator<uint32_t> rng_type;
+    
+    /// Proxy Authenticator policy
+    typedef websocketpp::lib::security::SecurityContext security_context;
+    typedef http::proxy::proxy_authenticator<security_context> proxy_authenticator_type;      
 
     /// Controls compile time enabling/disabling of thread syncronization
-    /// code Disabling can provide a minor performance improvement to single
-    /// threaded applications
     static bool const enable_multithreading = true;
 
     struct transport_config {

--- a/websocketpp/config/debug_asio.hpp
+++ b/websocketpp/config/debug_asio.hpp
@@ -58,6 +58,8 @@ struct debug_asio_tls : public debug_core {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+    
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -65,6 +67,7 @@ struct debug_asio_tls : public debug_core {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/debug_asio_no_tls.hpp
+++ b/websocketpp/config/debug_asio_no_tls.hpp
@@ -53,6 +53,8 @@ struct debug_asio : public debug_core {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+    
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -61,6 +63,7 @@ struct debug_asio : public debug_core {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -167,10 +167,15 @@ typedef lib::function<void(lib::error_code const & ec)> write_frame_handler;
      * @todo Move this to configs to allow compile/runtime disabling or enabling
      * of protocol versions
      */
+#ifdef _WIN32
+// Incorrect warning from VStudio compiler
 #pragma warning(push)
 #pragma warning(disable:4592)
+#endif
     static std::vector<int> const versions_supported = {0,7,8,13};
+#ifdef _WIN32
 #pragma warning(pop)
+#endif
 #else
     /// Helper array to get around lack of initializer lists pre C++11
     static int const helper[] = {0,7,8,13};

--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -150,6 +150,12 @@ typedef lib::function<bool(connection_hdl)> validate_handler;
  */
 typedef lib::function<void(connection_hdl)> http_handler;
 
+/// Reconnection handler
+/**
+  * 
+  */
+typedef lib::function<void(connection_hdl)> reconnect_handler;
+
 //
 typedef lib::function<void(lib::error_code const & ec, size_t bytes_transferred)> read_handler;
 typedef lib::function<void(lib::error_code const & ec)> write_frame_handler;
@@ -161,7 +167,10 @@ typedef lib::function<void(lib::error_code const & ec)> write_frame_handler;
      * @todo Move this to configs to allow compile/runtime disabling or enabling
      * of protocol versions
      */
+#pragma warning(push)
+#pragma warning(disable:4592)
     static std::vector<int> const versions_supported = {0,7,8,13};
+#pragma warning(pop)
 #else
     /// Helper array to get around lack of initializer lists pre C++11
     static int const helper[] = {0,7,8,13};
@@ -271,6 +280,9 @@ public:
     typedef typename config::con_msg_manager_type con_msg_manager_type;
     typedef typename con_msg_manager_type::ptr con_msg_manager_ptr;
 
+    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
+    typedef typename proxy_authenticator_type::ptr proxy_authenticator_ptr;
+
     /// Type of RNG
     typedef typename config::rng_type rng_type;
 
@@ -286,10 +298,14 @@ public:
     // Misc Convenience Types
     typedef session::internal_state::value istate_type;
 
+    // Reconnect handler (Signalled if we require a reconnection)
+    typedef lib::function<void(connection_hdl)> reconnect_handler;
+
 private:
     enum terminate_status {
         failed = 1,
         closed,
+        proxy_reconnect, // may not need this!
         unknown
     };
 public:
@@ -472,6 +488,16 @@ public:
      */
     void set_message_handler(message_handler h) {
         m_message_handler = h;
+    }
+
+    void set_reconnect_handler(reconnect_handler h) {
+        m_reconnect_handler = h;
+    }
+
+    void set_proxy_authenticator(proxy_authenticator_ptr a) {
+        m_proxy_authenticator = a;
+
+        config::transport_type::transport_con_type::set_proxy_authenticator(a);
     }
 
     //////////////////////////////////////////
@@ -1510,6 +1536,7 @@ private:
     http_handler            m_http_handler;
     validate_handler        m_validate_handler;
     message_handler         m_message_handler;
+    reconnect_handler       m_reconnect_handler;
 
     /// constant values
     long                    m_open_handshake_timeout_dur;
@@ -1597,6 +1624,7 @@ private:
     response_type           m_response;
     uri_ptr                 m_uri;
     std::string             m_subprotocol;
+    proxy_authenticator_ptr m_proxy_authenticator;
 
     // connection data that might not be necessary to keep around for the life
     // of the whole connection.

--- a/websocketpp/http/impl/proxy_authenticator_impl.hpp
+++ b/websocketpp/http/impl/proxy_authenticator_impl.hpp
@@ -121,7 +121,7 @@ namespace websocketpp {
                     }
 
                     template <typename InputIterator>
-                    inline InputIterator parse(InputIterator begin, InputIterator end) {
+                    InputIterator parse(InputIterator begin, InputIterator end) {
                         auto cursor = http::parser::extract_all_lws(begin, end);
 
                         switch (m_type)
@@ -129,6 +129,10 @@ namespace websocketpp {
                         case Basic:     return parse_basic(cursor, end);
                         case NTLM:      return parse_ntlm_negotiate(cursor, end);
                         case Negotiate: return parse_ntlm_negotiate(cursor, end);
+                        
+                        case Unknown:   break;
+                        case Digest:    break;
+                        default:        break;
                         }
 
                         return begin;
@@ -143,7 +147,7 @@ namespace websocketpp {
                     std::string m_realm;
 
                     template <typename InputIterator>
-                    inline InputIterator parse_basic(InputIterator begin, InputIterator end) {
+                    InputIterator parse_basic(InputIterator begin, InputIterator end) {
                         auto cursor = begin;
 
                         while (cursor != end) {
@@ -227,7 +231,7 @@ namespace websocketpp {
                 typedef std::vector<AuthScheme> AuthSchemes;
 
                 template <typename InputIterator>
-                inline std::pair<AuthScheme, InputIterator> parse_auth_scheme(InputIterator begin, InputIterator end) {
+                std::pair<AuthScheme, InputIterator> parse_auth_scheme(InputIterator begin, InputIterator end) {
                     auto cursor = http::parser::extract_all_lws(begin, end);
 
                     auto next = http::parser::extract_token(cursor, end);
@@ -246,7 +250,7 @@ namespace websocketpp {
                 }
 
                 template <typename InputIterator>
-                inline AuthSchemes parse_auth_schemes(InputIterator begin, InputIterator end) {
+                AuthSchemes parse_auth_schemes(InputIterator begin, InputIterator end) {
                     AuthSchemes auth_schemes;
 
                     InputIterator cursor = begin;

--- a/websocketpp/http/impl/proxy_authenticator_impl.hpp
+++ b/websocketpp/http/impl/proxy_authenticator_impl.hpp
@@ -1,0 +1,342 @@
+/*
+* Copyright (c) 2016, Peter Thorson. All rights reserved.
+*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the WebSocket++ Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The initial version of this Security Context policy was contributed to the WebSocket++
+ * project by Colie McGarry.
+ */
+
+#ifndef HTTP_PROXY_AUTHENTICATOR_IMPL_HPP
+#define HTTP_PROXY_AUTHENTICATOR_IMPL_HPP
+
+#include <websocketpp/base64/base64.hpp>
+
+#include <string>
+#include <algorithm>
+#include <locale>
+#include <cctype>
+
+namespace websocketpp {
+    namespace http {
+        namespace proxy {
+            namespace auth_parser {
+                /**
+                * Ref: https://tools.ietf.org/html/rfc7235 "2.1 Challenge and Response"
+                *
+                * challenge   = auth-scheme [ 1*SP ( token68 / #auth-param ) ]
+                *
+                * and in our case auth-scheme is one of "NTLM", "Negotiate", "Basic" or "Digest"
+                *
+                * auth-param     = token BWS "=" BWS ( token / quoted-string )
+                *
+                * BWS is basically 'optional' white space
+                *
+                * token68        = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
+                *
+                *
+                * Note: Digest is not implemented - we do parse, but we do not calculate tokens (yet)!
+                */
+
+                inline bool icompareCh(char lhs, char rhs) {
+                    return(::toupper(lhs) == ::toupper(rhs));
+                }
+                inline bool icompare(const std::string& s1, const std::string& s2) {
+                    return((s1.size() == s2.size()) &&
+                        std::equal(s1.begin(), s1.end(), s2.begin(), icompareCh));
+                }
+
+                /// Read and return the next token in the stream
+                inline bool is_token68_char(unsigned char c) {
+                    if (::isalpha(c)) return true;
+                    if (::isdigit(c)) return true;
+
+                    switch (c) {
+                    case '-': return true;
+                    case '.': return true;
+                    case '_': return true;
+                    case '~': return true;
+                    case '+': return true;
+                    case '/': return true;
+                    case '=': return true; // padding char (not strictly part of the 68!)
+                    }
+
+                    return false;
+                }
+                /// Is the character a non-token
+                inline bool is_not_token68_char(unsigned char c) {
+                    return !is_token68_char(c);
+                }
+                template <typename InputIterator>
+                std::pair<std::string, InputIterator> extract_token68(InputIterator begin,
+                    InputIterator end)
+                {
+                    InputIterator it = std::find_if(begin, end, &is_not_token68_char);
+                    return std::make_pair(std::string(begin, it), it);
+                }
+
+                class AuthScheme
+                {
+                public:
+                    AuthScheme(const std::string& name="") : m_name(name), m_type(Unknown)
+                    {
+                        if (icompare(m_name, "basic"))      m_type = Basic;
+                        if (icompare(m_name, "digest"))     m_type = Digest;
+                        if (icompare(m_name, "ntlm"))       m_type = NTLM;
+                        if (icompare(m_name, "negotiate"))  m_type = Negotiate;
+                    }
+
+                    std::string get_name()      const { return m_name;      }
+                    std::string get_challenge() const { return m_challenge; }
+                    std::string get_realm()     const { return m_realm;     }
+
+                    bool is_known()     const { return m_type == Unknown   ? false : true; }
+                    bool is_basic()     const { return m_type == Basic     ? true : false; }
+                    bool is_digest()    const { return m_type == Digest    ? true : false; }
+                    bool is_ntlm()      const { return m_type == NTLM      ? true : false; }
+                    bool is_negotiate() const { return m_type == Negotiate ? true : false; }
+
+                    static bool comparePriority(AuthScheme const& lhs, AuthScheme const& rhs) {
+                        return lhs.m_type > rhs.m_type;
+                    }
+
+                    template <typename InputIterator>
+                    inline InputIterator parse(InputIterator begin, InputIterator end) {
+                        auto cursor = http::parser::extract_all_lws(begin, end);
+
+                        switch (m_type)
+                        {
+                        case Basic:     return parse_basic(cursor, end);
+                        case NTLM:      return parse_ntlm_negotiate(cursor, end);
+                        case Negotiate: return parse_ntlm_negotiate(cursor, end);
+                        }
+
+                        return begin;
+                    }
+
+                private:
+                    enum scheme_type { Unknown, Basic, Digest, NTLM, Negotiate };
+
+                    std::string m_name;
+                    scheme_type m_type;
+                    std::string m_challenge;
+                    std::string m_realm;
+
+                    template <typename InputIterator>
+                    inline InputIterator parse_basic(InputIterator begin, InputIterator end) {
+                        auto cursor = begin;
+
+                        while (cursor != end) {
+                            cursor = http::parser::extract_all_lws(cursor, end);
+
+                            auto next = http::parser::extract_token(cursor, end);
+
+                            if (next.first.empty()) {
+                                return cursor;
+                            }
+
+                            if (AuthScheme(next.first).is_known()) {
+                                return cursor;
+                            }
+
+                            auto key = next.first;
+
+                            cursor = next.second;
+
+                            if (cursor == end || *cursor != '=') {
+                                // Expected a '=' char as part of a key value pair
+                                m_type = Unknown; 
+
+                                return cursor;
+                            }
+
+                            // Advance past the '='
+                            ++cursor;
+
+                            if (cursor == end) {
+                                // No Value
+                                m_type = Unknown;
+
+                                return cursor;
+                            }
+
+                            next = http::parser::extract_quoted_string(cursor, end);
+
+                            if (next.first.empty()) {
+                                next = http::parser::extract_token(cursor, end);
+                            }
+
+                            if (next.first.empty()) {
+                                // Expected a '=' char as part of a key value pair
+                                m_type = Unknown;
+
+                                return cursor;
+                            }
+
+                            if (icompare(key, "Realm")) {
+                                m_realm = next.first;
+                            }
+
+                            cursor = next.second;
+
+                            if (cursor != end && *cursor == ',') {
+                                ++cursor;
+                            }
+                        }
+
+                        return cursor;
+                    }
+
+                    template <typename InputIterator>
+                    InputIterator parse_ntlm_negotiate(InputIterator begin, InputIterator end) {
+                        auto cursor = http::parser::extract_all_lws(begin, end);
+
+                        auto next = extract_token68(cursor, end);
+
+                        if (!next.first.empty()) {
+                            m_challenge = next.first;
+
+                            cursor = next.second;
+                        }
+
+                        return cursor;
+                    }
+
+                };
+
+                typedef std::vector<AuthScheme> AuthSchemes;
+
+                template <typename InputIterator>
+                inline std::pair<AuthScheme, InputIterator> parse_auth_scheme(InputIterator begin, InputIterator end) {
+                    auto cursor = http::parser::extract_all_lws(begin, end);
+
+                    auto next = http::parser::extract_token(cursor, end);
+
+                    AuthScheme scheme(next.first);
+
+                    if (scheme.is_known()) {
+                        cursor = next.second;
+
+                        if (next.second != end) {
+                            cursor = scheme.parse(cursor, end);
+                        }
+                    }
+
+                    return std::make_pair(scheme, cursor);
+                }
+
+                template <typename InputIterator>
+                inline AuthSchemes parse_auth_schemes(InputIterator begin, InputIterator end) {
+                    AuthSchemes auth_schemes;
+
+                    InputIterator cursor = begin;
+
+                    while (cursor != end) {
+                        auto next = parse_auth_scheme(cursor, end);
+
+                        if (!next.first.is_known()) {
+                            return AuthSchemes();
+                        }
+
+                        auth_schemes.push_back(next.first);
+
+                        cursor = next.second;
+
+                        if (cursor != end && *cursor == ',') {
+                            ++cursor;
+                        }
+                    }
+
+                    return auth_schemes;
+                }
+
+                AuthScheme select_auth_scheme(std::string const & auth_headers)
+                {
+                    auto auth_schemes = parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+                    if (auth_schemes.empty()) {
+                        return AuthScheme();
+                    }
+
+                    std::stable_sort(auth_schemes.begin(), auth_schemes.end(), AuthScheme::comparePriority);
+
+                    return auth_schemes.front();
+                }
+
+                AuthScheme parse_auth_scheme(std::string const & auth_header) {
+                    auto result = parse_auth_scheme(auth_header.begin(), auth_header.end());
+
+                    return result.first;
+                }
+            }
+
+            //
+            // 'proxy_authenticator' implementation
+            //
+            template <typename security_context>
+            bool proxy_authenticator<security_context>::next_token(const std::string& auth_headers)
+            {
+                auth_parser::AuthScheme auth_scheme = auth_parser::select_auth_scheme(auth_headers);
+
+                if (!auth_scheme.is_known()) {
+                    return false;
+                }
+
+                if (auth_scheme.is_basic())
+                {
+                    m_auth_scheme_name = auth_scheme.get_name();
+
+                    // TODO: username can't contain ':' (Comment copied from old basic auth implementation)
+                    m_auth_token = base64_encode(m_basic_auth.username + ":" + m_basic_auth.password);
+
+                    return !m_basic_auth.username.empty();
+                }
+
+                if (auth_scheme.is_ntlm() || auth_scheme.is_negotiate())
+                {
+                    if (!m_security_context) {
+                        m_auth_scheme_name = auth_scheme.get_name();
+
+                        m_security_context = security_context::build(m_proxy, m_auth_scheme_name);
+                    }
+
+                    if (!m_security_context) {
+                        return false;
+                    }
+
+                    m_security_context->nextAuthToken(auth_scheme.get_challenge());
+
+                    m_auth_token = m_security_context->getUpdatedToken();
+
+                    return m_auth_token.empty() ? false : true;
+                }
+
+                return false;
+            }
+        }   // namespace proxy
+    }       // namespace http
+}           // namespace websocketpp
+
+//#include <websocketpp/http/impl/proxy_authenticator.hpp>
+
+#endif // HTTP_PROXY_AUTHENTICATOR_IMPL_HPP

--- a/websocketpp/http/impl/proxy_authenticator_impl.hpp
+++ b/websocketpp/http/impl/proxy_authenticator_impl.hpp
@@ -122,7 +122,7 @@ namespace websocketpp {
 
                     template <typename InputIterator>
                     InputIterator parse(InputIterator begin, InputIterator end) {
-                        auto cursor = http::parser::extract_all_lws(begin, end);
+                        InputIterator cursor = http::parser::extract_all_lws(begin, end);
 
                         switch (m_type)
                         {
@@ -148,12 +148,12 @@ namespace websocketpp {
 
                     template <typename InputIterator>
                     InputIterator parse_basic(InputIterator begin, InputIterator end) {
-                        auto cursor = begin;
+                        InputIterator cursor = begin;
 
                         while (cursor != end) {
                             cursor = http::parser::extract_all_lws(cursor, end);
 
-                            auto next = http::parser::extract_token(cursor, end);
+                            std::pair<std::string, InputIterator> next = http::parser::extract_token(cursor, end);
 
                             if (next.first.empty()) {
                                 return cursor;
@@ -163,7 +163,7 @@ namespace websocketpp {
                                 return cursor;
                             }
 
-                            auto key = next.first;
+                            std::string key = next.first;
 
                             cursor = next.second;
 
@@ -213,9 +213,9 @@ namespace websocketpp {
 
                     template <typename InputIterator>
                     InputIterator parse_ntlm_negotiate(InputIterator begin, InputIterator end) {
-                        auto cursor = http::parser::extract_all_lws(begin, end);
+                        InputIterator cursor = http::parser::extract_all_lws(begin, end);
 
-                        auto next = extract_token68(cursor, end);
+                        std::pair<std::string, InputIterator> next = extract_token68(cursor, end);
 
                         if (!next.first.empty()) {
                             m_challenge = next.first;
@@ -232,9 +232,9 @@ namespace websocketpp {
 
                 template <typename InputIterator>
                 std::pair<AuthScheme, InputIterator> parse_auth_scheme(InputIterator begin, InputIterator end) {
-                    auto cursor = http::parser::extract_all_lws(begin, end);
+                    InputIterator cursor = http::parser::extract_all_lws(begin, end);
 
-                    auto next = http::parser::extract_token(cursor, end);
+                    std::pair<std::string, InputIterator> next = http::parser::extract_token(cursor, end);
 
                     AuthScheme scheme(next.first);
 
@@ -256,7 +256,7 @@ namespace websocketpp {
                     InputIterator cursor = begin;
 
                     while (cursor != end) {
-                        auto next = parse_auth_scheme(cursor, end);
+                        std::pair<AuthScheme,InputIterator> next = parse_auth_scheme(cursor, end);
 
                         if (!next.first.is_known()) {
                             return AuthSchemes();
@@ -276,7 +276,7 @@ namespace websocketpp {
 
                 AuthScheme select_auth_scheme(std::string const & auth_headers)
                 {
-                    auto auth_schemes = parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+                    AuthSchemes auth_schemes = parse_auth_schemes(auth_headers.begin(), auth_headers.end());
 
                     if (auth_schemes.empty()) {
                         return AuthScheme();
@@ -288,7 +288,7 @@ namespace websocketpp {
                 }
 
                 AuthScheme parse_auth_scheme(std::string const & auth_header) {
-                    auto result = parse_auth_scheme(auth_header.begin(), auth_header.end());
+                    std::pair<AuthScheme, std::string::const_iterator> result = parse_auth_scheme(auth_header.begin(), auth_header.end());
 
                     return result.first;
                 }

--- a/websocketpp/http/impl/proxy_authenticator_impl.hpp
+++ b/websocketpp/http/impl/proxy_authenticator_impl.hpp
@@ -88,7 +88,7 @@ namespace websocketpp {
                     return !is_token68_char(c);
                 }
                 template <typename InputIterator>
-                std::pair<std::string, InputIterator> extract_token68(InputIterator begin,
+                inline std::pair<std::string, InputIterator> extract_token68(InputIterator begin,
                     InputIterator end)
                 {
                     InputIterator it = std::find_if(begin, end, &is_not_token68_char);
@@ -231,7 +231,7 @@ namespace websocketpp {
                 typedef std::vector<AuthScheme> AuthSchemes;
 
                 template <typename InputIterator>
-                std::pair<AuthScheme, InputIterator> parse_auth_scheme(InputIterator begin, InputIterator end) {
+                inline std::pair<AuthScheme, InputIterator> parse_auth_scheme(InputIterator begin, InputIterator end) {
                     InputIterator cursor = http::parser::extract_all_lws(begin, end);
 
                     std::pair<std::string, InputIterator> next = http::parser::extract_token(cursor, end);
@@ -250,7 +250,7 @@ namespace websocketpp {
                 }
 
                 template <typename InputIterator>
-                AuthSchemes parse_auth_schemes(InputIterator begin, InputIterator end) {
+                inline AuthSchemes parse_auth_schemes(InputIterator begin, InputIterator end) {
                     AuthSchemes auth_schemes;
 
                     InputIterator cursor = begin;
@@ -274,7 +274,7 @@ namespace websocketpp {
                     return auth_schemes;
                 }
 
-                AuthScheme select_auth_scheme(std::string const & auth_headers)
+                inline AuthScheme select_auth_scheme(std::string const & auth_headers)
                 {
                     AuthSchemes auth_schemes = parse_auth_schemes(auth_headers.begin(), auth_headers.end());
 
@@ -287,7 +287,7 @@ namespace websocketpp {
                     return auth_schemes.front();
                 }
 
-                AuthScheme parse_auth_scheme(std::string const & auth_header) {
+                inline AuthScheme parse_auth_scheme(std::string const & auth_header) {
                     std::pair<AuthScheme, std::string::const_iterator> result = parse_auth_scheme(auth_header.begin(), auth_header.end());
 
                     return result.first;

--- a/websocketpp/http/proxy_authenticator.hpp
+++ b/websocketpp/http/proxy_authenticator.hpp
@@ -1,0 +1,171 @@
+/*
+* Copyright (c) 2016, Peter Thorson. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the WebSocket++ Project nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The initial version of this Security Context policy was contributed to the WebSocket++
+* project by Colie McGarry.
+*/
+
+#ifndef HTTP_PROXY_AUTHENTICATOR_HPP
+#define HTTP_PROXY_AUTHENTICATOR_HPP
+
+#include <websocketpp/common/memory.hpp>
+
+#include <websocketpp/http/response.hpp>
+
+#include <string>
+#include <algorithm>
+#include <locale>
+#include <cctype>
+
+namespace websocketpp {
+    namespace http {
+        namespace proxy {
+
+            /// The 'proxy_authenticator' manages parsing and tokens required for proxy autentication.
+            /**
+            * The proxy authenticator handles http proxy authentication. It supports 'Basic', 'NTLM'
+            * and 'Negotiate' authentation - depending on the security context object used. Currently 
+            * there is a Win32 security context which will authenticate using the signed on users
+            * credentials for NTLM and Negotiate. 
+            *
+            * Where the proxy supports multiple different auth schemes, the proxy authenticator will 
+            * select the scheme using the following priority:
+            *   1. Negotiate
+            *   2. NTLM
+            *   3. Digest (not supported just now)
+            *   4. Basic
+            *  
+            */
+            template <typename security_context>
+            class proxy_authenticator {
+            private:
+                typedef typename security_context::Ptr security_context_ptr;
+
+                std::string m_proxy;
+                std::string m_auth_scheme_name;
+                std::string m_auth_token;
+                bool authenticated=false;
+
+                struct
+                {
+                    std::string username;
+                    std::string password;
+
+                } m_basic_auth;
+
+                security_context_ptr m_security_context;
+
+                std::string build_auth_response() {
+                    if (!m_auth_scheme_name.empty() && !m_auth_token.empty()) {
+                        return m_auth_scheme_name + " " + m_auth_token;
+                    }
+
+                    return "";
+                }
+
+            public:
+                typedef lib::shared_ptr<proxy_authenticator> ptr;
+
+                /// Construct a 'proxy_authenticator'
+                /**
+                * Constructs a proxy authenticator fo a given proxy
+                *
+                * @param proxy: Complete proxy URI eg http://proxy.example.com:8080/
+                */
+                proxy_authenticator(std::string const& proxy) : m_proxy(proxy) {
+                }
+
+                /// Set Basice authentication credentials
+                /**
+                * This method sets the basic auth credentials. This can be used for Basic 
+                * authentication, and Digest, however only Basic is supported just now.
+                *
+                * @param username: username used in the auth response.
+                * @param password: password used in the aut response
+                */
+                void set_basic_auth(std::string const& username, std::string const& password)
+                {
+                    m_basic_auth.username = username;
+                    m_basic_auth.password = password;
+                }
+
+                /// Calculate the next auth token
+                /**
+                * Using the reponse from the proxy, be that the initial response with a list
+                * of auth schemes, or a subsequent response with a scheme and a challenge token,
+                * this method will calculate the next auth token to be used. 
+                *
+                * @param auth_headers: Response headers from 'Proxy-Authenticate'
+                *
+                * Return: ture:  New token calculated, continue auth flow.
+                *         false: No new token calculated - fail the auth flow
+                */
+                bool next_token(std::string const& auth_headers);
+
+                /// Return the next calculated auth token
+                /**
+                * This method will return the next calculated auth token for use in the 
+                * 'Proxy-Authorization' header field.
+                *
+                * Return: New Auth token for 'Proxy-Authorization' header.
+                */
+                std::string get_auth_token() {
+                    return build_auth_response();
+                }
+
+                /// To be called after 'proxy_authentication' is complete
+                /**
+                * Marks this authenticator as complete, which means 'get_authenticated_token()
+                * returns the valid token for proxy authentication. 
+                */
+                void set_authenticated() {
+                    authenticated = true;
+                }
+
+                /// Returns the authenticated token after auth complete
+                /**
+                * 
+                */
+                std::string get_authenticated_token() {
+                    return authenticated ? build_auth_response() : "";
+                }
+
+                /// Returns the proxy uri
+                /**
+                * 
+                */
+                std::string get_proxy() {
+                    return m_proxy;
+                }
+
+            };
+
+        }   // namespace proxy
+    }       // namespace http
+}           // namespace websocketpp
+
+#include <websocketpp/http/impl/proxy_authenticator_impl.hpp>
+
+#endif // HTTP_PROXY_AUTHENTICATOR_HPP

--- a/websocketpp/http/proxy_authenticator.hpp
+++ b/websocketpp/http/proxy_authenticator.hpp
@@ -66,7 +66,7 @@ namespace websocketpp {
                 std::string m_proxy;
                 std::string m_auth_scheme_name;
                 std::string m_auth_token;
-                bool authenticated=false;
+                bool authenticated;
 
                 struct
                 {
@@ -94,7 +94,7 @@ namespace websocketpp {
                 *
                 * @param proxy: Complete proxy URI eg http://proxy.example.com:8080/
                 */
-                proxy_authenticator(std::string const& proxy) : m_proxy(proxy) {
+                proxy_authenticator(std::string const& proxy) : m_proxy(proxy), authenticated(false) {
                 }
 
                 /// Set Basice authentication credentials

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -748,6 +748,19 @@ void connection<config>::handle_transport_init(lib::error_code const & ec) {
         ecm = error::make_error_code(error::invalid_state);
     }
 
+    if (ecm == transport::error::proxy_reconnect)
+    {
+        m_elog.write(log::elevel::rerror, "handle_transport_init proxy reconned required");
+
+        if(m_reconnect_handler) {
+            m_reconnect_handler(m_connection_hdl);
+
+            return;
+        }
+
+        return;
+    }
+
     if (ecm) {
         std::stringstream s;
         s << "handle_transport_init received error: "<< ecm.message();

--- a/websocketpp/impl/endpoint_impl.hpp
+++ b/websocketpp/impl/endpoint_impl.hpp
@@ -66,7 +66,8 @@ endpoint<connection,config>::create_connection() {
     con->set_http_handler(m_http_handler);
     con->set_validate_handler(m_validate_handler);
     con->set_message_handler(m_message_handler);
-
+    con->set_reconnect_handler(m_reconnect_handler);
+    
     if (m_open_handshake_timeout_dur != config::timeout_open_handshake) {
         con->set_open_handshake_timeout(m_open_handshake_timeout_dur);
     }
@@ -80,6 +81,11 @@ endpoint<connection,config>::create_connection() {
         con->set_max_message_size(m_max_message_size);
     }
     con->set_max_http_body_size(m_max_http_body_size);
+
+    if (m_proxy_authenticator)
+    {
+        con->set_proxy_authenticator(m_proxy_authenticator);
+    }
 
     lib::error_code ec;
 

--- a/websocketpp/roles/client_endpoint.hpp
+++ b/websocketpp/roles/client_endpoint.hpp
@@ -67,6 +67,8 @@ public:
     /// Type of the endpoint component of this server
     typedef endpoint<connection_type,config> endpoint_type;
 
+    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
+
     friend class connection<config>;
 
     explicit client() : endpoint_type(false)

--- a/websocketpp/roles/server_endpoint.hpp
+++ b/websocketpp/roles/server_endpoint.hpp
@@ -64,6 +64,8 @@ public:
     /// Type of the endpoint component of this server
     typedef endpoint<connection_type,config> endpoint_type;
 
+    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
+
     friend class connection<config>;
 
     explicit server() : endpoint_type(true)

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -92,6 +92,10 @@ public:
     /// Type of a pointer to the Asio timer class
     typedef lib::shared_ptr<lib::asio::steady_timer> timer_ptr;
 
+    /// Type of proxy authentication policy
+    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
+    typedef typename proxy_authenticator_type::ptr proxy_authenticator_ptr;
+
     // connection is friends with its associated endpoint to allow the endpoint
     // to call private/protected utility methods that we don't want to expose
     // to the public api.
@@ -182,6 +186,9 @@ public:
      * The proxy must be set up as an explicit (CONNECT) proxy allowed to
      * connect to the port you specify. Traffic to the proxy is not encrypted.
      *
+     * Note: Method to be Deprecated. Call the 'set_proxy' method on the endpoint
+     *       object instead. 
+     *
      * @param uri The full URI of the proxy to connect to.
      *
      * @param ec A status value
@@ -201,12 +208,24 @@ public:
         if (ec) { throw exception(ec); }
     }
 
+    void set_proxy_authenticator(proxy_authenticator_ptr p) {
+        m_proxy = p->get_proxy();
+        m_proxy_data = lib::make_shared<proxy_data>();
+
+        if (m_proxy_data) {
+            m_proxy_data->proxy_authenticator = p;
+        }
+    }
+
     /// Set the basic auth credentials to use (exception free)
     /**
      * The URI passed should be a complete URI including scheme. For example:
      * http://proxy.example.com:8080/
      *
      * The proxy must be set up as an explicit proxy
+     *
+     * Note: Method to be Deprecated. Call the 'set_proxy_basic_auth' method on the endpoint
+     *       object instead.
      *
      * @param username The username to send
      *
@@ -222,9 +241,10 @@ public:
             return;
         }
 
-        // TODO: username can't contain ':'
-        std::string val = "Basic "+base64_encode(username + ":" + password);
-        m_proxy_data->req.replace_header("Proxy-Authorization",val);
+        if (m_proxy_data->proxy_authenticator) {
+            m_proxy_data->proxy_authenticator->set_basic_auth(username, password);
+        }
+
         ec = lib::error_code();
     }
 
@@ -442,7 +462,17 @@ protected:
         m_proxy_data->req.set_method("CONNECT");
 
         m_proxy_data->req.set_uri(authority);
-        m_proxy_data->req.replace_header("Host",authority);
+        m_proxy_data->req.replace_header("Host", authority);
+        //m_proxy)data->req.replace_header("Connection", "Keep-alive");
+
+        if (m_proxy_data->proxy_authenticator) {
+
+            auto auth_token = m_proxy_data->proxy_authenticator->get_auth_token();
+
+            if (!auth_token.empty()) {
+                m_proxy_data->req.replace_header("Proxy-Authorization", auth_token);
+            }
+        }
 
         return lib::error_code();
     }
@@ -784,6 +814,46 @@ protected:
             }
 
             m_alog.write(log::alevel::devel,m_proxy_data->res.raw());
+
+            bool reconnect = false;
+
+            auto connection_header = m_proxy_data->res.get_header("Connection");
+
+            if (connection_header == "Close") {
+                reconnect = true;
+            }
+
+            if (m_proxy_data->res.get_status_code() == http::status_code::proxy_authentication_required) {
+                m_elog.write(log::elevel::info, "Proxy authorization Required");
+
+                auto auth_headers = m_proxy_data->res.get_header("Proxy-Authenticate");
+
+                if (m_proxy_data->proxy_authenticator) {
+
+                    auto next_token = m_proxy_data->proxy_authenticator->next_token(auth_headers);
+
+                    if (next_token && !reconnect) {
+                        m_proxy_data->res = response_type();
+                        m_proxy_data->req.replace_header("Proxy-Authorization", m_proxy_data->proxy_authenticator->get_auth_token());
+
+                        proxy_write(callback);
+
+                        return;
+                    }
+                }
+            }
+
+            if (m_proxy_data->proxy_authenticator) {
+                if (m_proxy_data->res.get_status_code() == http::status_code::ok) {
+                    m_proxy_data->proxy_authenticator->set_authenticated();
+                }
+
+                if (reconnect) {
+                    callback(make_error_code(transport::error::proxy_reconnect));
+
+                    return;
+                }
+            }
 
             if (m_proxy_data->res.get_status_code() != http::status_code::ok) {
                 // got an error response back
@@ -1173,6 +1243,7 @@ private:
         lib::asio::streambuf read_buf;
         long timeout_proxy;
         timer_ptr timer;
+        proxy_authenticator_ptr proxy_authenticator;
     };
 
     std::string m_proxy;

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -467,7 +467,7 @@ protected:
 
         if (m_proxy_data->proxy_authenticator) {
 
-            auto auth_token = m_proxy_data->proxy_authenticator->get_auth_token();
+            std::string auth_token = m_proxy_data->proxy_authenticator->get_auth_token();
 
             if (!auth_token.empty()) {
                 m_proxy_data->req.replace_header("Proxy-Authorization", auth_token);
@@ -817,7 +817,7 @@ protected:
 
             bool reconnect = false;
 
-            auto connection_header = m_proxy_data->res.get_header("Connection");
+            atd::string connection_header = m_proxy_data->res.get_header("Connection");
 
             if (connection_header == "Close") {
                 reconnect = true;
@@ -826,11 +826,11 @@ protected:
             if (m_proxy_data->res.get_status_code() == http::status_code::proxy_authentication_required) {
                 m_elog.write(log::elevel::info, "Proxy authorization Required");
 
-                auto auth_headers = m_proxy_data->res.get_header("Proxy-Authenticate");
+                std::string auth_headers = m_proxy_data->res.get_header("Proxy-Authenticate");
 
                 if (m_proxy_data->proxy_authenticator) {
 
-                    auto next_token = m_proxy_data->proxy_authenticator->next_token(auth_headers);
+                    bool next_token = m_proxy_data->proxy_authenticator->next_token(auth_headers);
 
                     if (next_token && !reconnect) {
                         m_proxy_data->res = response_type();

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -817,7 +817,7 @@ protected:
 
             bool reconnect = false;
 
-            atd::string connection_header = m_proxy_data->res.get_header("Connection");
+            std::string connection_header = m_proxy_data->res.get_header("Connection");
 
             if (connection_header == "Close") {
                 reconnect = true;

--- a/websocketpp/transport/base/connection.hpp
+++ b/websocketpp/transport/base/connection.hpp
@@ -177,7 +177,10 @@ enum value {
     action_after_shutdown,
 
     /// Other TLS error
-    tls_error
+    tls_error,
+
+    /// Proxy Reconnection required
+    proxy_reconnect,
 };
 
 class category : public lib::error_category {

--- a/websocketpp/transport/debug/connection.hpp
+++ b/websocketpp/transport/debug/connection.hpp
@@ -72,7 +72,11 @@ public:
     typedef typename concurrency_type::mutex_type mutex_type;
 
     typedef lib::shared_ptr<timer> timer_ptr;
-
+    
+    /// Type of proxy authentication policy
+    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
+    typedef typename proxy_authenticator_type::ptr proxy_authenticator_ptr;
+    
     explicit connection(bool is_server, alog_type & alog, elog_type & elog)
       : m_reading(false), m_is_server(is_server), m_alog(alog), m_elog(elog)
     {
@@ -207,6 +211,11 @@ public:
     void fullfil_write() {
         m_write_handler(lib::error_code());
     }
+
+    // NB: Remove me. Only added to debug build break
+    void set_proxy_authenticator(proxy_authenticator_ptr) {
+    }
+    
 protected:
     /// Initialize the connection transport
     /**

--- a/websocketpp/transport/iostream/connection.hpp
+++ b/websocketpp/transport/iostream/connection.hpp
@@ -75,6 +75,10 @@ public:
     typedef typename concurrency_type::scoped_lock_type scoped_lock_type;
     typedef typename concurrency_type::mutex_type mutex_type;
 
+    /// Type of proxy authentication policy
+    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
+    typedef typename proxy_authenticator_type::ptr proxy_authenticator_ptr;
+    
     typedef lib::shared_ptr<timer> timer_ptr;
 
     explicit connection(bool is_server, alog_type & alog, elog_type & elog)
@@ -92,6 +96,11 @@ public:
     /// Get a shared pointer to this component
     ptr get_shared() {
         return type::shared_from_this();
+    }
+
+    /// NB: REMOVE ME 
+    //  Only included to help figure out CI build break.
+    void set_proxy_authenticator(proxy_authenticator_ptr p) {
     }
 
     /// Register a std::ostream with the transport for writing output

--- a/websocketpp/transport/iostream/connection.hpp
+++ b/websocketpp/transport/iostream/connection.hpp
@@ -100,7 +100,7 @@ public:
 
     /// NB: REMOVE ME 
     //  Only included to help figure out CI build break.
-    void set_proxy_authenticator(proxy_authenticator_ptr p) {
+    void set_proxy_authenticator(proxy_authenticator_ptr) {
     }
 
     /// Register a std::ostream with the transport for writing output

--- a/websocketpp/transport/iostream/connection.hpp
+++ b/websocketpp/transport/iostream/connection.hpp
@@ -76,11 +76,7 @@ public:
     typedef typename concurrency_type::mutex_type mutex_type;
 
     typedef lib::shared_ptr<timer> timer_ptr;
-    
-    /// Type of proxy authentication policy
-    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
-    typedef typename proxy_authenticator_type::ptr proxy_authenticator_ptr;
-    
+
     explicit connection(bool is_server, alog_type & alog, elog_type & elog)
       : m_output_stream(NULL)
       , m_reading(false)
@@ -97,12 +93,6 @@ public:
     ptr get_shared() {
         return type::shared_from_this();
     }
-    
-    //
-    // To Do: Remove this - only adding to fix a build break. 
-    //
-    void set_proxy_authenticator(proxy_authenticator_ptr p) {
-    }    
 
     /// Register a std::ostream with the transport for writing output
     /**

--- a/websocketpp/transport/iostream/connection.hpp
+++ b/websocketpp/transport/iostream/connection.hpp
@@ -76,7 +76,11 @@ public:
     typedef typename concurrency_type::mutex_type mutex_type;
 
     typedef lib::shared_ptr<timer> timer_ptr;
-
+    
+    /// Type of proxy authentication policy
+    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
+    typedef typename proxy_authenticator_type::ptr proxy_authenticator_ptr;
+    
     explicit connection(bool is_server, alog_type & alog, elog_type & elog)
       : m_output_stream(NULL)
       , m_reading(false)
@@ -93,6 +97,12 @@ public:
     ptr get_shared() {
         return type::shared_from_this();
     }
+    
+    //
+    // To Do: Remove this - only adding to fix a build break. 
+    //
+    void set_proxy_authenticator(proxy_authenticator_ptr p) {
+    }    
 
     /// Register a std::ostream with the transport for writing output
     /**


### PR DESCRIPTION
Added Proxy Authorization support.

New pluggable 'proxy_authorization' policy which handles http proxy authorization. The default implementation of this includes:
- Proxy Auth header parser (extracts scheme + challenge).
- Supports NTLM+Negotiate+Basic (Did not include 'Digest' at this time)
- Handles NTLM/Negotiate tokens using a security_context policy. 

Added Unit Tests for Proxy Authorization Parsing. 

The change includes an implementation of a windows security_context policy using the Windows SSPI interface. This header may be better suited to live outside the library, however as I've implemented it, I think it fits pretty well with the current design. It only comes into play if you include this policy (via config), which results (on windows in extra link time dependencies)

I added a new config policy to show how to include a proxy authenticated web socket i.e. asio_tls_client_authenticated_proxy. 

I needed a small API change i.e. to handle re-connection request from the proxy. When a proxy_reconnect is reported from the library, the client code drops current connection, and creates a new connection. Since the proxy authorization object lives with the 'endpoint' it lives across this re-connection and is then used in the next steps. 

With the introduction of a proxy_authenticator, some APIs (set_proxy + set_proxy_basic_auth), now more naturally live with the endpoint, rather than the connection. So there are new API's on the end point. I did leave the existing methods on the connection to avoid and breaking API change, but I did include a comment to indicate that these methods are now deprecated. 

I've tested with both basic auth, and NTLM auth since we have these setups here. I do plan to test next with Negotiate, since we have a customer with this configuration. 

Please review and let me know what you think. 

