### PR TITLE
Fix shutdown bugs by holding loggers in shared_ptrs

### DIFF
--- a/test/connection/connection.cpp
+++ b/test/connection/connection.cpp
@@ -132,11 +132,14 @@ struct debug_config_client : public websocketpp::config::core {
 };
 
 struct connection_setup {
-    connection_setup(bool p_is_server) : c(p_is_server, "", alog, elog, rng) {}
+    connection_setup(bool p_is_server)
+            : alog(websocketpp::lib::make_shared<stub_config::alog_type>())
+            , elog(websocketpp::lib::make_shared<stub_config::elog_type>())
+            , c(p_is_server, "", alog, elog, rng) {}
 
     websocketpp::lib::error_code ec;
-    stub_config::alog_type alog;
-    stub_config::elog_type elog;
+    websocketpp::lib::shared_ptr<stub_config::alog_type> alog;
+    websocketpp::lib::shared_ptr<stub_config::elog_type> elog;
     stub_config::rng_type rng;
     websocketpp::connection<stub_config> c;
 };

--- a/test/transport/asio/timers.cpp
+++ b/test/transport/asio/timers.cpp
@@ -115,7 +115,9 @@ context_ptr on_tls_init(websocketpp::connection_hdl) {
 struct mock_con: public websocketpp::transport::asio::connection<config> {
     typedef websocketpp::transport::asio::connection<config> base;
 
-    mock_con(bool a, config::alog_type& b, config::elog_type& c) : base(a,b,c) {}
+    mock_con(bool a, const websocketpp::lib::shared_ptr<config::alog_type>& b,
+             const websocketpp::lib::shared_ptr<config::elog_type>& c)
+            : base(a,b,c) {}
 
     void start() {
         base::init(websocketpp::lib::bind(&mock_con::handle_start,this,
@@ -139,8 +141,8 @@ struct mock_endpoint : public websocketpp::transport::asio::endpoint<config> {
     typedef websocketpp::transport::asio::endpoint<config> base;
 
     mock_endpoint() {
-        alog.set_channels(websocketpp::log::alevel::all);
-        base::init_logging(&alog,&elog);
+        alog->set_channels(websocketpp::log::alevel::all);
+        base::init_logging(alog,elog);
         init_asio();
     }
 
@@ -170,8 +172,8 @@ struct mock_endpoint : public websocketpp::transport::asio::endpoint<config> {
     }
 
     connection_ptr m_con;
-    config::alog_type alog;
-    config::elog_type elog;
+    websocketpp::lib::shared_ptr<config::alog_type> alog;
+    websocketpp::lib::shared_ptr<config::elog_type> elog;
 };
 
 BOOST_AUTO_TEST_CASE( tls_handshake_timeout ) {

--- a/test/transport/iostream/connection.cpp
+++ b/test/transport/iostream/connection.cpp
@@ -58,7 +58,7 @@ struct stub_con : public iostream_con {
     typedef websocketpp::lib::shared_ptr<type> ptr;
     typedef iostream_con::timer_ptr timer_ptr;
 
-    stub_con(bool is_server, config::alog_type & a, config::elog_type & e)
+    stub_con(bool is_server, const websocketpp::lib::shared_ptr<config::alog_type>& a, const websocketpp::lib::shared_ptr<config::elog_type>& e)
         : iostream_con(is_server,a,e)
         // Set the error to a known code that is unused by the library
         // This way we can easily confirm that the handler was run at all.
@@ -164,8 +164,8 @@ struct stub_con : public iostream_con {
 };
 
 // Stubs
-config::alog_type alogger;
-config::elog_type elogger;
+websocketpp::lib::shared_ptr<config::alog_type> alogger = websocketpp::lib::make_shared<config::alog_type>();
+websocketpp::lib::shared_ptr<config::elog_type> elogger = websocketpp::lib::make_shared<config::elog_type>();
 
 BOOST_AUTO_TEST_CASE( const_methods ) {
     iostream_con::ptr con(new iostream_con(true,alogger,elogger));

--- a/websocketpp/config/core.hpp
+++ b/websocketpp/config/core.hpp
@@ -49,6 +49,7 @@
 
 // Loggers
 #include <websocketpp/logger/basic.hpp>
+#include <websocketpp/logger/levels.hpp>
 
 // RNG
 #include <websocketpp/random/none.hpp>

--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -294,8 +294,8 @@ private:
     };
 public:
 
-    explicit connection(bool p_is_server, std::string const & ua, alog_type& alog,
-        elog_type& elog, rng_type & rng)
+    explicit connection(bool p_is_server, std::string const & ua, const lib::shared_ptr<alog_type>& alog,
+                        const lib::shared_ptr<elog_type>& elog, rng_type & rng)
       : transport_con_type(p_is_server, alog, elog)
       , m_handle_read_frame(lib::bind(
             &type::handle_read_frame,
@@ -329,7 +329,7 @@ public:
       , m_http_state(session::http_state::init)
       , m_was_clean(false)
     {
-        m_alog.write(log::alevel::devel,"connection constructor");
+        m_alog->write(log::alevel::devel,"connection constructor");
     }
 
     /// Get a shared pointer to this component
@@ -1486,7 +1486,7 @@ private:
     void log_err(log::level l, char const * msg, error_type const & ec) {
         std::stringstream s;
         s << msg << " error: " << ec << " (" << ec.message() << ")";
-        m_elog.write(l, s.str());
+        m_elog->write(l, s.str());
     }
 
     // internal handler functions
@@ -1603,8 +1603,8 @@ private:
     std::vector<std::string> m_requested_subprotocols;
 
     bool const              m_is_server;
-    alog_type& m_alog;
-    elog_type& m_elog;
+    const lib::shared_ptr<alog_type> m_alog;
+    const lib::shared_ptr<elog_type> m_elog;
 
     rng_type & m_rng;
 

--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -89,8 +89,8 @@ public:
     //friend connection;
 
     explicit endpoint(bool p_is_server)
-      : m_alog(config::alog_level, log::channel_type_hint::access)
-      , m_elog(config::elog_level, log::channel_type_hint::error)
+      : m_alog(new alog_type(config::alog_level, log::channel_type_hint::access))
+      , m_elog(new elog_type(config::elog_level, log::channel_type_hint::error))
       , m_user_agent(::websocketpp::user_agent)
       , m_open_handshake_timeout_dur(config::timeout_open_handshake)
       , m_close_handshake_timeout_dur(config::timeout_close_handshake)
@@ -99,12 +99,12 @@ public:
       , m_max_http_body_size(config::max_http_body_size)
       , m_is_server(p_is_server)
     {
-        m_alog.set_channels(config::alog_level);
-        m_elog.set_channels(config::elog_level);
+        m_alog->set_channels(config::alog_level);
+        m_elog->set_channels(config::elog_level);
 
-        m_alog.write(log::alevel::devel, "endpoint constructor");
+        m_alog->write(log::alevel::devel, "endpoint constructor");
 
-        transport_type::init_logging(&m_alog, &m_elog);
+        transport_type::init_logging(m_alog, m_elog);
     }
 
 
@@ -218,7 +218,7 @@ public:
      * @param channels The channel value(s) to set
      */
     void set_access_channels(log::level channels) {
-        m_alog.set_channels(channels);
+        m_alog->set_channels(channels);
     }
 
     /// Clear Access logging channels
@@ -229,7 +229,7 @@ public:
      * @param channels The channel value(s) to clear
      */
     void clear_access_channels(log::level channels) {
-        m_alog.clear_channels(channels);
+        m_alog->clear_channels(channels);
     }
 
     /// Set Error logging channel
@@ -240,7 +240,7 @@ public:
      * @param channels The channel value(s) to set
      */
     void set_error_channels(log::level channels) {
-        m_elog.set_channels(channels);
+        m_elog->set_channels(channels);
     }
 
     /// Clear Error logging channels
@@ -251,7 +251,7 @@ public:
      * @param channels The channel value(s) to clear
      */
     void clear_error_channels(log::level channels) {
-        m_elog.clear_channels(channels);
+        m_elog->clear_channels(channels);
     }
 
     /// Get reference to access logger
@@ -259,7 +259,7 @@ public:
      * @return A reference to the access logger
      */
     alog_type & get_alog() {
-        return m_alog;
+        return *m_alog;
     }
 
     /// Get reference to error logger
@@ -267,7 +267,7 @@ public:
      * @return A reference to the error logger
      */
     elog_type & get_elog() {
-        return m_elog;
+        return *m_elog;
     }
 
     /*************************/
@@ -275,52 +275,52 @@ public:
     /*************************/
 
     void set_open_handler(open_handler h) {
-        m_alog.write(log::alevel::devel,"set_open_handler");
+        m_alog->write(log::alevel::devel,"set_open_handler");
         scoped_lock_type guard(m_mutex);
         m_open_handler = h;
     }
     void set_close_handler(close_handler h) {
-        m_alog.write(log::alevel::devel,"set_close_handler");
+        m_alog->write(log::alevel::devel,"set_close_handler");
         scoped_lock_type guard(m_mutex);
         m_close_handler = h;
     }
     void set_fail_handler(fail_handler h) {
-        m_alog.write(log::alevel::devel,"set_fail_handler");
+        m_alog->write(log::alevel::devel,"set_fail_handler");
         scoped_lock_type guard(m_mutex);
         m_fail_handler = h;
     }
     void set_ping_handler(ping_handler h) {
-        m_alog.write(log::alevel::devel,"set_ping_handler");
+        m_alog->write(log::alevel::devel,"set_ping_handler");
         scoped_lock_type guard(m_mutex);
         m_ping_handler = h;
     }
     void set_pong_handler(pong_handler h) {
-        m_alog.write(log::alevel::devel,"set_pong_handler");
+        m_alog->write(log::alevel::devel,"set_pong_handler");
         scoped_lock_type guard(m_mutex);
         m_pong_handler = h;
     }
     void set_pong_timeout_handler(pong_timeout_handler h) {
-        m_alog.write(log::alevel::devel,"set_pong_timeout_handler");
+        m_alog->write(log::alevel::devel,"set_pong_timeout_handler");
         scoped_lock_type guard(m_mutex);
         m_pong_timeout_handler = h;
     }
     void set_interrupt_handler(interrupt_handler h) {
-        m_alog.write(log::alevel::devel,"set_interrupt_handler");
+        m_alog->write(log::alevel::devel,"set_interrupt_handler");
         scoped_lock_type guard(m_mutex);
         m_interrupt_handler = h;
     }
     void set_http_handler(http_handler h) {
-        m_alog.write(log::alevel::devel,"set_http_handler");
+        m_alog->write(log::alevel::devel,"set_http_handler");
         scoped_lock_type guard(m_mutex);
         m_http_handler = h;
     }
     void set_validate_handler(validate_handler h) {
-        m_alog.write(log::alevel::devel,"set_validate_handler");
+        m_alog->write(log::alevel::devel,"set_validate_handler");
         scoped_lock_type guard(m_mutex);
         m_validate_handler = h;
     }
     void set_message_handler(message_handler h) {
-        m_alog.write(log::alevel::devel,"set_message_handler");
+        m_alog->write(log::alevel::devel,"set_message_handler");
         scoped_lock_type guard(m_mutex);
         m_message_handler = h;
     }
@@ -661,8 +661,8 @@ public:
 protected:
     connection_ptr create_connection();
 
-    alog_type m_alog;
-    elog_type m_elog;
+    lib::shared_ptr<alog_type> m_alog;
+    lib::shared_ptr<elog_type> m_elog;
 private:
     // dynamic settings
     std::string                 m_user_agent;

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -53,7 +53,7 @@ template <typename config>
 void connection<config>::set_termination_handler(
     termination_handler new_handler)
 {
-    m_alog.write(log::alevel::devel,
+    m_alog->write(log::alevel::devel,
         "connection set_termination_handler");
 
     //scoped_lock_type lock(m_connection_state_lock);
@@ -103,8 +103,8 @@ lib::error_code connection<config>::send(void const * payload, size_t len,
 template <typename config>
 lib::error_code connection<config>::send(typename config::message_type::ptr msg)
 {
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"connection send");
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"connection send");
     }
 
     {
@@ -153,8 +153,8 @@ lib::error_code connection<config>::send(typename config::message_type::ptr msg)
 
 template <typename config>
 void connection<config>::ping(std::string const& payload, lib::error_code& ec) {
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"connection ping");
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"connection ping");
     }
 
     {
@@ -162,7 +162,7 @@ void connection<config>::ping(std::string const& payload, lib::error_code& ec) {
         if (m_state != session::state::open) {
             std::stringstream ss;
             ss << "connection::ping called from invalid state " << m_state;
-            m_alog.write(log::alevel::devel,ss.str());
+            m_alog->write(log::alevel::devel,ss.str());
             ec = error::make_error_code(error::invalid_state);
             return;
         }
@@ -198,7 +198,7 @@ void connection<config>::ping(std::string const& payload, lib::error_code& ec) {
 
         if (!m_ping_timer) {
             // Our transport doesn't support timers
-            m_elog.write(log::elevel::warn,"Warning: a pong_timeout_handler is \
+            m_elog->write(log::elevel::warn,"Warning: a pong_timeout_handler is \
                 set but the transport in use does not support timeouts.");
         }
     }
@@ -239,7 +239,7 @@ void connection<config>::handle_pong_timeout(std::string payload,
             return;
         }
 
-        m_elog.write(log::elevel::devel,"pong_timeout error: "+ec.message());
+        m_elog->write(log::elevel::devel,"pong_timeout error: "+ec.message());
         return;
     }
 
@@ -250,8 +250,8 @@ void connection<config>::handle_pong_timeout(std::string payload,
 
 template <typename config>
 void connection<config>::pong(std::string const& payload, lib::error_code& ec) {
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"connection pong");
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"connection pong");
     }
 
     {
@@ -259,7 +259,7 @@ void connection<config>::pong(std::string const& payload, lib::error_code& ec) {
         if (m_state != session::state::open) {
             std::stringstream ss;
             ss << "connection::pong called from invalid state " << m_state;
-            m_alog.write(log::alevel::devel,ss.str());
+            m_alog->write(log::alevel::devel,ss.str());
             ec = error::make_error_code(error::invalid_state);
             return;
         }
@@ -304,8 +304,8 @@ template <typename config>
 void connection<config>::close(close::status::value const code,
     std::string const & reason, lib::error_code & ec)
 {
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"connection close");
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"connection close");
     }
 
     // Truncate reason to maximum size allowable in a close frame.
@@ -339,7 +339,7 @@ void connection<config>::close(close::status::value const code,
  */
 template <typename config>
 lib::error_code connection<config>::interrupt() {
-    m_alog.write(log::alevel::devel,"connection connection::interrupt");
+    m_alog->write(log::alevel::devel,"connection connection::interrupt");
     return transport_con_type::interrupt(
         lib::bind(
             &type::handle_interrupt,
@@ -358,7 +358,7 @@ void connection<config>::handle_interrupt() {
 
 template <typename config>
 lib::error_code connection<config>::pause_reading() {
-    m_alog.write(log::alevel::devel,"connection connection::pause_reading");
+    m_alog->write(log::alevel::devel,"connection connection::pause_reading");
     return transport_con_type::dispatch(
         lib::bind(
             &type::handle_pause_reading,
@@ -370,13 +370,13 @@ lib::error_code connection<config>::pause_reading() {
 /// Pause reading handler. Not safe to call directly
 template <typename config>
 void connection<config>::handle_pause_reading() {
-    m_alog.write(log::alevel::devel,"connection connection::handle_pause_reading");
+    m_alog->write(log::alevel::devel,"connection connection::handle_pause_reading");
     m_read_flag = false;
 }
 
 template <typename config>
 lib::error_code connection<config>::resume_reading() {
-    m_alog.write(log::alevel::devel,"connection connection::resume_reading");
+    m_alog->write(log::alevel::devel,"connection connection::resume_reading");
     return transport_con_type::dispatch(
         lib::bind(
             &type::handle_resume_reading,
@@ -714,10 +714,10 @@ void connection<config>::send_http_response() {
 
 template <typename config>
 void connection<config>::start() {
-    m_alog.write(log::alevel::devel,"connection start");
+    m_alog->write(log::alevel::devel,"connection start");
 
     if (m_internal_state != istate::USER_INIT) {
-        m_alog.write(log::alevel::devel,"Start called in invalid state");
+        m_alog->write(log::alevel::devel,"Start called in invalid state");
         this->terminate(error::make_error_code(error::invalid_state));
         return;
     }
@@ -738,12 +738,12 @@ void connection<config>::start() {
 
 template <typename config>
 void connection<config>::handle_transport_init(lib::error_code const & ec) {
-    m_alog.write(log::alevel::devel,"connection handle_transport_init");
+    m_alog->write(log::alevel::devel,"connection handle_transport_init");
 
     lib::error_code ecm = ec;
 
     if (m_internal_state != istate::TRANSPORT_INIT) {
-        m_alog.write(log::alevel::devel,
+        m_alog->write(log::alevel::devel,
           "handle_transport_init must be called from transport init state");
         ecm = error::make_error_code(error::invalid_state);
     }
@@ -751,7 +751,7 @@ void connection<config>::handle_transport_init(lib::error_code const & ec) {
     if (ecm) {
         std::stringstream s;
         s << "handle_transport_init received error: "<< ecm.message();
-        m_elog.write(log::elevel::rerror,s.str());
+        m_elog->write(log::elevel::rerror,s.str());
 
         this->terminate(ecm);
         return;
@@ -772,7 +772,7 @@ void connection<config>::handle_transport_init(lib::error_code const & ec) {
 
 template <typename config>
 void connection<config>::read_handshake(size_t num_bytes) {
-    m_alog.write(log::alevel::devel,"connection read_handshake");
+    m_alog->write(log::alevel::devel,"connection read_handshake");
 
     if (m_open_handshake_timeout_dur > 0) {
         m_handshake_timer = transport_con_type::set_timer(
@@ -804,7 +804,7 @@ template <typename config>
 void connection<config>::handle_read_handshake(lib::error_code const & ec,
     size_t bytes_transferred)
 {
-    m_alog.write(log::alevel::devel,"connection handle_read_handshake");
+    m_alog->write(log::alevel::devel,"connection handle_read_handshake");
 
     lib::error_code ecm = ec;
 
@@ -819,7 +819,7 @@ void connection<config>::handle_read_handshake(lib::error_code const & ec,
             // The connection was canceled while the response was being sent,
             // usually by the handshake timer. This is basically expected
             // (though hopefully rare) and there is nothing we can do so ignore.
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 "handle_read_handshake invoked after connection was closed");
             return;
         } else {
@@ -830,7 +830,7 @@ void connection<config>::handle_read_handshake(lib::error_code const & ec,
     if (ecm) {
         if (ecm == transport::error::eof && m_state == session::state::closed) {
             // we expect to get eof if the connection is closed already
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                     "got (expected) eof/state error from closed con");
             return;
         }
@@ -842,7 +842,7 @@ void connection<config>::handle_read_handshake(lib::error_code const & ec,
 
     // Boundaries checking. TODO: How much of this should be done?
     if (bytes_transferred > config::connection_read_buffer_size) {
-        m_elog.write(log::elevel::fatal,"Fatal boundaries checking error.");
+        m_elog->write(log::elevel::fatal,"Fatal boundaries checking error.");
         this->terminate(make_error_code(error::general));
         return;
     }
@@ -861,16 +861,16 @@ void connection<config>::handle_read_handshake(lib::error_code const & ec,
     // More paranoid boundaries checking.
     // TODO: Is this overkill?
     if (bytes_processed > bytes_transferred) {
-        m_elog.write(log::elevel::fatal,"Fatal boundaries checking error.");
+        m_elog->write(log::elevel::fatal,"Fatal boundaries checking error.");
         this->terminate(make_error_code(error::general));
         return;
     }
 
-    if (m_alog.static_test(log::alevel::devel)) {
+    if (m_alog->static_test(log::alevel::devel)) {
         std::stringstream s;
         s << "bytes_transferred: " << bytes_transferred
           << " bytes, bytes processed: " << bytes_processed << " bytes";
-        m_alog.write(log::alevel::devel,s.str());
+        m_alog->write(log::alevel::devel,s.str());
     }
 
     if (m_request.ready()) {
@@ -891,17 +891,17 @@ void connection<config>::handle_read_handshake(lib::error_code const & ec,
                 bytes_processed += 8;
             } else {
                 // TODO: need more bytes
-                m_alog.write(log::alevel::devel,"short key3 read");
+                m_alog->write(log::alevel::devel,"short key3 read");
                 m_response.set_status(http::status_code::internal_server_error);
                 this->write_http_response_error(processor::error::make_error_code(processor::error::short_key3));
                 return;
             }
         }
 
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,m_request.raw());
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,m_request.raw());
             if (!m_request.get_header("Sec-WebSocket-Key3").empty()) {
-                m_alog.write(log::alevel::devel,
+                m_alog->write(log::alevel::devel,
                     utility::to_hex(m_request.get_header("Sec-WebSocket-Key3")));
             }
         }
@@ -948,7 +948,7 @@ void connection<config>::handle_read_handshake(lib::error_code const & ec,
 template <typename config>
 void connection<config>::write_http_response_error(lib::error_code const & ec) {
     if (m_internal_state != istate::READ_HTTP_REQUEST) {
-        m_alog.write(log::alevel::devel,
+        m_alog->write(log::alevel::devel,
             "write_http_response_error called in invalid state");
         this->terminate(error::make_error_code(error::invalid_state));
         return;
@@ -965,7 +965,7 @@ template <typename config>
 void connection<config>::handle_read_frame(lib::error_code const & ec,
     size_t bytes_transferred)
 {
-    //m_alog.write(log::alevel::devel,"connection handle_read_frame");
+    //m_alog->write(log::alevel::devel,"connection handle_read_frame");
 
     lib::error_code ecm = ec;
 
@@ -980,7 +980,7 @@ void connection<config>::handle_read_frame(lib::error_code const & ec,
             if (m_state == session::state::closed) {
                 // we expect to get eof if the connection is closed already
                 // just ignore it
-                m_alog.write(log::alevel::devel,"got eof from closed con");
+                m_alog->write(log::alevel::devel,"got eof from closed con");
                 return;
             } else if (m_state == session::state::closing && !m_is_server) {
                 // If we are a client we expect to get eof in the closing state,
@@ -995,7 +995,7 @@ void connection<config>::handle_read_frame(lib::error_code const & ec,
             // changed and should be ignored as they pose no problems and there
             // is nothing useful that we can do about them.
             if (m_state == session::state::closed) {
-                m_alog.write(log::alevel::devel,
+                m_alog->write(log::alevel::devel,
                     "handle_read_frame: got invalid istate in closed state");
                 return;
             }
@@ -1019,32 +1019,32 @@ void connection<config>::handle_read_frame(lib::error_code const & ec,
 
     // Boundaries checking. TODO: How much of this should be done?
     /*if (bytes_transferred > config::connection_read_buffer_size) {
-        m_elog.write(log::elevel::fatal,"Fatal boundaries checking error");
+        m_elog->write(log::elevel::fatal,"Fatal boundaries checking error");
         this->terminate(make_error_code(error::general));
         return;
     }*/
 
     size_t p = 0;
 
-    if (m_alog.static_test(log::alevel::devel)) {
+    if (m_alog->static_test(log::alevel::devel)) {
         std::stringstream s;
         s << "p = " << p << " bytes transferred = " << bytes_transferred;
-        m_alog.write(log::alevel::devel,s.str());
+        m_alog->write(log::alevel::devel,s.str());
     }
 
     while (p < bytes_transferred) {
-        if (m_alog.static_test(log::alevel::devel)) {
+        if (m_alog->static_test(log::alevel::devel)) {
             std::stringstream s;
             s << "calling consume with " << bytes_transferred-p << " bytes";
-            m_alog.write(log::alevel::devel,s.str());
+            m_alog->write(log::alevel::devel,s.str());
         }
 
         lib::error_code consume_ec;
 
-        if (m_alog.static_test(log::alevel::devel)) {
+        if (m_alog->static_test(log::alevel::devel)) {
             std::stringstream s;
             s << "Processing Bytes: " << utility::to_hex(reinterpret_cast<uint8_t*>(m_buf)+p,bytes_transferred-p);
-            m_alog.write(log::alevel::devel,s.str());
+            m_alog->write(log::alevel::devel,s.str());
         }
 
         p += m_processor->consume(
@@ -1053,10 +1053,10 @@ void connection<config>::handle_read_frame(lib::error_code const & ec,
             consume_ec
         );
 
-        if (m_alog.static_test(log::alevel::devel)) {
+        if (m_alog->static_test(log::alevel::devel)) {
             std::stringstream s;
             s << "bytes left after consume: " << bytes_transferred-p;
-            m_alog.write(log::alevel::devel,s.str());
+            m_alog->write(log::alevel::devel,s.str());
         }
         if (consume_ec) {
             log_err(log::elevel::rerror, "consume", consume_ec);
@@ -1082,20 +1082,20 @@ void connection<config>::handle_read_frame(lib::error_code const & ec,
         }
 
         if (m_processor->ready()) {
-            if (m_alog.static_test(log::alevel::devel)) {
+            if (m_alog->static_test(log::alevel::devel)) {
                 std::stringstream s;
                 s << "Complete message received. Dispatching";
-                m_alog.write(log::alevel::devel,s.str());
+                m_alog->write(log::alevel::devel,s.str());
             }
 
             message_ptr msg = m_processor->get_message();
 
             if (!msg) {
-                m_alog.write(log::alevel::devel, "null message from m_processor");
+                m_alog->write(log::alevel::devel, "null message from m_processor");
             } else if (!is_control(msg->get_opcode())) {
                 // data message, dispatch to user
                 if (m_state != session::state::open) {
-                    m_elog.write(log::elevel::warn, "got non-close frame while closing");
+                    m_elog->write(log::elevel::warn, "got non-close frame while closing");
                 } else if (m_message_handler) {
                     m_message_handler(m_connection_hdl, msg);
                 }
@@ -1132,7 +1132,7 @@ void connection<config>::read_frame() {
 
 template <typename config>
 lib::error_code connection<config>::initialize_processor() {
-    m_alog.write(log::alevel::devel,"initialize_processor");
+    m_alog->write(log::alevel::devel,"initialize_processor");
 
     // if it isn't a websocket handshake nothing to do.
     if (!processor::is_websocket_handshake(m_request)) {
@@ -1142,7 +1142,7 @@ lib::error_code connection<config>::initialize_processor() {
     int version = processor::get_websocket_version(m_request);
 
     if (version < 0) {
-        m_alog.write(log::alevel::devel, "BAD REQUEST: can't determine version");
+        m_alog->write(log::alevel::devel, "BAD REQUEST: can't determine version");
         m_response.set_status(http::status_code::bad_request);
         return error::make_error_code(error::invalid_version);
     }
@@ -1156,7 +1156,7 @@ lib::error_code connection<config>::initialize_processor() {
 
     // We don't have a processor for this version. Return bad request
     // with Sec-WebSocket-Version header filled with values we do accept
-    m_alog.write(log::alevel::devel, "BAD REQUEST: no processor for version");
+    m_alog->write(log::alevel::devel, "BAD REQUEST: no processor for version");
     m_response.set_status(http::status_code::bad_request);
 
     std::stringstream ss;
@@ -1174,11 +1174,11 @@ lib::error_code connection<config>::initialize_processor() {
 
 template <typename config>
 lib::error_code connection<config>::process_handshake_request() {
-    m_alog.write(log::alevel::devel,"process handshake request");
+    m_alog->write(log::alevel::devel,"process handshake request");
 
     if (!processor::is_websocket_handshake(m_request)) {
         // this is not a websocket handshake. Process as plain HTTP
-        m_alog.write(log::alevel::devel,"HTTP REQUEST");
+        m_alog->write(log::alevel::devel,"HTTP REQUEST");
 
         // extract URI from request
         m_uri = processor::get_uri_from_host(
@@ -1187,7 +1187,7 @@ lib::error_code connection<config>::process_handshake_request() {
         );
 
         if (!m_uri->get_valid()) {
-            m_alog.write(log::alevel::devel, "Bad request: failed to parse uri");
+            m_alog->write(log::alevel::devel, "Bad request: failed to parse uri");
             m_response.set_status(http::status_code::bad_request);
             return error::make_error_code(error::invalid_uri);
         }
@@ -1212,7 +1212,7 @@ lib::error_code connection<config>::process_handshake_request() {
     // Validate: make sure all required elements are present.
     if (ec){
         // Not a valid handshake request
-        m_alog.write(log::alevel::devel, "Bad request " + ec.message());
+        m_alog->write(log::alevel::devel, "Bad request " + ec.message());
         m_response.set_status(http::status_code::bad_request);
         return ec;
     }
@@ -1225,7 +1225,7 @@ lib::error_code connection<config>::process_handshake_request() {
     if (neg_results.first) {
         // There was a fatal error in extension parsing that should result in
         // a failed connection attempt.
-        m_alog.write(log::alevel::devel, "Bad request: " + neg_results.first.message());
+        m_alog->write(log::alevel::devel, "Bad request: " + neg_results.first.message());
         m_response.set_status(http::status_code::bad_request);
         return neg_results.first;
     } else {
@@ -1243,7 +1243,7 @@ lib::error_code connection<config>::process_handshake_request() {
 
 
     if (!m_uri->get_valid()) {
-        m_alog.write(log::alevel::devel, "Bad request: failed to parse uri");
+        m_alog->write(log::alevel::devel, "Bad request: failed to parse uri");
         m_response.set_status(http::status_code::bad_request);
         return error::make_error_code(error::invalid_uri);
     }
@@ -1267,14 +1267,14 @@ lib::error_code connection<config>::process_handshake_request() {
         if (ec) {
             std::stringstream s;
             s << "Processing error: " << ec << "(" << ec.message() << ")";
-            m_alog.write(log::alevel::devel, s.str());
+            m_alog->write(log::alevel::devel, s.str());
 
             m_response.set_status(http::status_code::internal_server_error);
             return ec;
         }
     } else {
         // User application has rejected the handshake
-        m_alog.write(log::alevel::devel, "USER REJECT");
+        m_alog->write(log::alevel::devel, "USER REJECT");
 
         // Use Bad Request if the user handler did not provide a more
         // specific http response error code.
@@ -1291,10 +1291,10 @@ lib::error_code connection<config>::process_handshake_request() {
 
 template <typename config>
 void connection<config>::write_http_response(lib::error_code const & ec) {
-    m_alog.write(log::alevel::devel,"connection write_http_response");
+    m_alog->write(log::alevel::devel,"connection write_http_response");
 
     if (ec == error::make_error_code(error::http_connection_ended)) {
-        m_alog.write(log::alevel::http,"An HTTP handler took over the connection.");
+        m_alog->write(log::alevel::http,"An HTTP handler took over the connection.");
         return;
     }
 
@@ -1324,10 +1324,10 @@ void connection<config>::write_http_response(lib::error_code const & ec) {
         m_handshake_buffer = m_response.raw();
     }
 
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"Raw Handshake response:\n"+m_handshake_buffer);
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"Raw Handshake response:\n"+m_handshake_buffer);
         if (!m_response.get_header("Sec-WebSocket-Key3").empty()) {
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 utility::to_hex(m_response.get_header("Sec-WebSocket-Key3")));
         }
     }
@@ -1346,7 +1346,7 @@ void connection<config>::write_http_response(lib::error_code const & ec) {
 
 template <typename config>
 void connection<config>::handle_write_http_response(lib::error_code const & ec) {
-    m_alog.write(log::alevel::devel,"handle_write_http_response");
+    m_alog->write(log::alevel::devel,"handle_write_http_response");
 
     lib::error_code ecm = ec;
 
@@ -1361,7 +1361,7 @@ void connection<config>::handle_write_http_response(lib::error_code const & ec) 
             // The connection was canceled while the response was being sent,
             // usually by the handshake timer. This is basically expected
             // (though hopefully rare) and there is nothing we can do so ignore.
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 "handle_write_http_response invoked after connection was closed");
             return;
         } else {
@@ -1372,7 +1372,7 @@ void connection<config>::handle_write_http_response(lib::error_code const & ec) 
     if (ecm) {
         if (ecm == transport::error::eof && m_state == session::state::closed) {
             // we expect to get eof if the connection is closed already
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                     "got (expected) eof/state error from closed con");
             return;
         }
@@ -1397,7 +1397,7 @@ void connection<config>::handle_write_http_response(lib::error_code const & ec) 
             std::stringstream s;
             s << "Handshake ended with HTTP error: "
               << m_response.get_status_code();
-            m_elog.write(log::elevel::rerror,s.str());
+            m_elog->write(log::elevel::rerror,s.str());
         } else {
             // if this was not a websocket connection, we have written
             // the expected response and the connection can be closed.
@@ -1405,7 +1405,7 @@ void connection<config>::handle_write_http_response(lib::error_code const & ec) 
             this->log_http_result();
             
             if (m_ec) {
-                m_alog.write(log::alevel::devel,
+                m_alog->write(log::alevel::devel,
                     "got to writing HTTP results with m_ec set: "+m_ec.message());
             }
             m_ec = make_error_code(error::http_connection_ended);
@@ -1429,7 +1429,7 @@ void connection<config>::handle_write_http_response(lib::error_code const & ec) 
 
 template <typename config>
 void connection<config>::send_http_request() {
-    m_alog.write(log::alevel::devel,"connection send_http_request");
+    m_alog->write(log::alevel::devel,"connection send_http_request");
 
     // TODO: origin header?
 
@@ -1445,7 +1445,7 @@ void connection<config>::send_http_request() {
             return;
         }
     } else {
-        m_elog.write(log::elevel::fatal,"Internal library error: missing processor");
+        m_elog->write(log::elevel::fatal,"Internal library error: missing processor");
         return;
     }
 
@@ -1460,8 +1460,8 @@ void connection<config>::send_http_request() {
 
     m_handshake_buffer = m_request.raw();
 
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"Raw Handshake request:\n"+m_handshake_buffer);
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"Raw Handshake request:\n"+m_handshake_buffer);
     }
 
     if (m_open_handshake_timeout_dur > 0) {
@@ -1488,7 +1488,7 @@ void connection<config>::send_http_request() {
 
 template <typename config>
 void connection<config>::handle_send_http_request(lib::error_code const & ec) {
-    m_alog.write(log::alevel::devel,"handle_send_http_request");
+    m_alog->write(log::alevel::devel,"handle_send_http_request");
 
     lib::error_code ecm = ec;
 
@@ -1505,7 +1505,7 @@ void connection<config>::handle_send_http_request(lib::error_code const & ec) {
             // The connection was canceled while the response was being sent,
             // usually by the handshake timer. This is basically expected
             // (though hopefully rare) and there is nothing we can do so ignore.
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 "handle_send_http_request invoked after connection was closed");
             return;
         } else {
@@ -1516,7 +1516,7 @@ void connection<config>::handle_send_http_request(lib::error_code const & ec) {
     if (ecm) {
         if (ecm == transport::error::eof && m_state == session::state::closed) {
             // we expect to get eof if the connection is closed already
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                     "got (expected) eof/state error from closed con");
             return;
         }
@@ -1543,7 +1543,7 @@ template <typename config>
 void connection<config>::handle_read_http_response(lib::error_code const & ec,
     size_t bytes_transferred)
 {
-    m_alog.write(log::alevel::devel,"handle_read_http_response");
+    m_alog->write(log::alevel::devel,"handle_read_http_response");
 
     lib::error_code ecm = ec;
 
@@ -1558,7 +1558,7 @@ void connection<config>::handle_read_http_response(lib::error_code const & ec,
             // The connection was canceled while the response was being sent,
             // usually by the handshake timer. This is basically expected
             // (though hopefully rare) and there is nothing we can do so ignore.
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 "handle_read_http_response invoked after connection was closed");
             return;
         } else {
@@ -1569,7 +1569,7 @@ void connection<config>::handle_read_http_response(lib::error_code const & ec,
     if (ecm) {
         if (ecm == transport::error::eof && m_state == session::state::closed) {
             // we expect to get eof if the connection is closed already
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                     "got (expected) eof/state error from closed con");
             return;
         }
@@ -1584,13 +1584,13 @@ void connection<config>::handle_read_http_response(lib::error_code const & ec,
     try {
         bytes_processed = m_response.consume(m_buf,bytes_transferred);
     } catch (http::exception & e) {
-        m_elog.write(log::elevel::rerror,
+        m_elog->write(log::elevel::rerror,
             std::string("error in handle_read_http_response: ")+e.what());
         this->terminate(make_error_code(error::general));
         return;
     }
 
-    m_alog.write(log::alevel::devel,std::string("Raw response: ")+m_response.raw());
+    m_alog->write(log::alevel::devel,std::string("Raw response: ")+m_response.raw());
 
     if (m_response.headers_ready()) {
         if (m_handshake_timer) {
@@ -1621,7 +1621,7 @@ void connection<config>::handle_read_http_response(lib::error_code const & ec,
             // doesn't match the options requested by the client. Its possible
             // that the best behavior in this cases is to log and continue with
             // an unextended connection.
-            m_alog.write(log::alevel::devel, "Extension negotiation failed: " 
+            m_alog->write(log::alevel::devel, "Extension negotiation failed: "
                 + neg_results.first.message());
             this->terminate(make_error_code(error::extension_neg_failed));
             // TODO: close connection with reason 1010 (and list extensions)
@@ -1664,13 +1664,13 @@ void connection<config>::handle_open_handshake_timeout(
     lib::error_code const & ec)
 {
     if (ec == transport::error::operation_aborted) {
-        m_alog.write(log::alevel::devel,"open handshake timer cancelled");
+        m_alog->write(log::alevel::devel,"open handshake timer cancelled");
     } else if (ec) {
-        m_alog.write(log::alevel::devel,
+        m_alog->write(log::alevel::devel,
             "open handle_open_handshake_timeout error: "+ec.message());
         // TODO: ignore or fail here?
     } else {
-        m_alog.write(log::alevel::devel,"open handshake timer expired");
+        m_alog->write(log::alevel::devel,"open handshake timer expired");
         terminate(make_error_code(error::open_handshake_timeout));
     }
 }
@@ -1680,21 +1680,21 @@ void connection<config>::handle_close_handshake_timeout(
     lib::error_code const & ec)
 {
     if (ec == transport::error::operation_aborted) {
-        m_alog.write(log::alevel::devel,"asio close handshake timer cancelled");
+        m_alog->write(log::alevel::devel,"asio close handshake timer cancelled");
     } else if (ec) {
-        m_alog.write(log::alevel::devel,
+        m_alog->write(log::alevel::devel,
             "asio open handle_close_handshake_timeout error: "+ec.message());
         // TODO: ignore or fail here?
     } else {
-        m_alog.write(log::alevel::devel, "asio close handshake timer expired");
+        m_alog->write(log::alevel::devel, "asio close handshake timer expired");
         terminate(make_error_code(error::close_handshake_timeout));
     }
 }
 
 template <typename config>
 void connection<config>::terminate(lib::error_code const & ec) {
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"connection terminate");
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"connection terminate");
     }
 
     // Cancel close handshake timer
@@ -1727,7 +1727,7 @@ void connection<config>::terminate(lib::error_code const & ec) {
         m_state = session::state::closed;
         tstat = closed;
     } else {
-        m_alog.write(log::alevel::devel,
+        m_alog->write(log::alevel::devel,
             "terminate called on connection that was already terminated");
         return;
     }
@@ -1748,8 +1748,8 @@ template <typename config>
 void connection<config>::handle_terminate(terminate_status tstat,
     lib::error_code const & ec)
 {
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"connection handle_terminate");
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"connection handle_terminate");
     }
 
     if (ec) {
@@ -1770,7 +1770,7 @@ void connection<config>::handle_terminate(terminate_status tstat,
         }
         log_close_result();
     } else {
-        m_elog.write(log::elevel::rerror,"Unknown terminate_status");
+        m_elog->write(log::elevel::rerror,"Unknown terminate_status");
     }
 
     // call the termination handler if it exists
@@ -1780,7 +1780,7 @@ void connection<config>::handle_terminate(terminate_status tstat,
         try {
             m_termination_handler(type::get_shared());
         } catch (std::exception const & e) {
-            m_elog.write(log::elevel::warn,
+            m_elog->write(log::elevel::warn,
                 std::string("termination_handler call failed. Reason was: ")+e.what());
         }
     }
@@ -1788,7 +1788,7 @@ void connection<config>::handle_terminate(terminate_status tstat,
 
 template <typename config>
 void connection<config>::write_frame() {
-    //m_alog.write(log::alevel::devel,"connection write_frame");
+    //m_alog->write(log::alevel::devel,"connection write_frame");
 
     {
         scoped_lock_type lock(m_write_lock);
@@ -1834,8 +1834,8 @@ void connection<config>::write_frame() {
     }
 
     // Print detailed send stats if those log levels are enabled
-    if (m_alog.static_test(log::alevel::frame_header)) {
-    if (m_alog.dynamic_test(log::alevel::frame_header)) {
+    if (m_alog->static_test(log::alevel::frame_header)) {
+    if (m_alog->dynamic_test(log::alevel::frame_header)) {
         std::stringstream general,header,payload;
         
         general << "Dispatching write containing " << m_current_msgs.size()
@@ -1855,8 +1855,8 @@ void connection<config>::write_frame() {
                    << m_current_msgs[i]->get_header().size() << ") " 
                    << utility::to_hex(m_current_msgs[i]->get_header()) << "\n";
 
-            if (m_alog.static_test(log::alevel::frame_payload)) {
-            if (m_alog.dynamic_test(log::alevel::frame_payload)) {
+            if (m_alog->static_test(log::alevel::frame_payload)) {
+            if (m_alog->dynamic_test(log::alevel::frame_payload)) {
                 payload << "[" << i << "] (" 
                         << m_current_msgs[i]->get_payload().size() << ") ["<<m_current_msgs[i]->get_opcode()<<"] "
                         << (m_current_msgs[i]->get_opcode() == frame::opcode::text ? 
@@ -1870,9 +1870,9 @@ void connection<config>::write_frame() {
         
         general << hbytes << " header bytes and " << pbytes << " payload bytes";
         
-        m_alog.write(log::alevel::frame_header,general.str());
-        m_alog.write(log::alevel::frame_header,header.str());
-        m_alog.write(log::alevel::frame_payload,payload.str());
+        m_alog->write(log::alevel::frame_header,general.str());
+        m_alog->write(log::alevel::frame_header,header.str());
+        m_alog->write(log::alevel::frame_payload,payload.str());
     }
     }
 
@@ -1885,8 +1885,8 @@ void connection<config>::write_frame() {
 template <typename config>
 void connection<config>::handle_write_frame(lib::error_code const & ec)
 {
-    if (m_alog.static_test(log::alevel::devel)) {
-        m_alog.write(log::alevel::devel,"connection handle_write_frame");
+    if (m_alog->static_test(log::alevel::devel)) {
+        m_alog->write(log::alevel::devel,"connection handle_write_frame");
     }
 
     bool terminal = m_current_msgs.back()->get_terminal();
@@ -1933,21 +1933,21 @@ std::vector<int> const & connection<config>::get_supported_versions() const
 template <typename config>
 void connection<config>::process_control_frame(typename config::message_type::ptr msg)
 {
-    m_alog.write(log::alevel::devel,"process_control_frame");
+    m_alog->write(log::alevel::devel,"process_control_frame");
 
     frame::opcode::value op = msg->get_opcode();
     lib::error_code ec;
 
     std::stringstream s;
     s << "Control frame received with opcode " << op;
-    m_alog.write(log::alevel::control,s.str());
+    m_alog->write(log::alevel::control,s.str());
 
     if (m_state == session::state::closed) {
-        m_elog.write(log::elevel::warn,"got frame in state closed");
+        m_elog->write(log::elevel::warn,"got frame in state closed");
         return;
     }
     if (op != frame::opcode::CLOSE && m_state != session::state::open) {
-        m_elog.write(log::elevel::warn,"got non-close frame in state closing");
+        m_elog->write(log::elevel::warn,"got non-close frame in state closing");
         return;
     }
 
@@ -1972,7 +1972,7 @@ void connection<config>::process_control_frame(typename config::message_type::pt
             m_ping_timer->cancel();
         }
     } else if (op == frame::opcode::CLOSE) {
-        m_alog.write(log::alevel::devel,"got close frame");
+        m_alog->write(log::alevel::devel,"got close frame");
         // record close code and reason somewhere
 
         m_remote_close_code = close::extract_code(msg->get_payload(),ec);
@@ -1981,12 +1981,12 @@ void connection<config>::process_control_frame(typename config::message_type::pt
             if (config::drop_on_protocol_error) {
                 s << "Received invalid close code " << m_remote_close_code
                   << " dropping connection per config.";
-                m_elog.write(log::elevel::devel,s.str());
+                m_elog->write(log::elevel::devel,s.str());
                 this->terminate(ec);
             } else {
                 s << "Received invalid close code " << m_remote_close_code
                   << " sending acknowledgement and closing";
-                m_elog.write(log::elevel::devel,s.str());
+                m_elog->write(log::elevel::devel,s.str());
                 ec = send_close_ack(close::status::protocol_error,
                     "Invalid close code");
                 if (ec) {
@@ -1999,11 +1999,11 @@ void connection<config>::process_control_frame(typename config::message_type::pt
         m_remote_close_reason = close::extract_reason(msg->get_payload(),ec);
         if (ec) {
             if (config::drop_on_protocol_error) {
-                m_elog.write(log::elevel::devel,
+                m_elog->write(log::elevel::devel,
                     "Received invalid close reason. Dropping connection per config");
                 this->terminate(ec);
             } else {
-                m_elog.write(log::elevel::devel,
+                m_elog->write(log::elevel::devel,
                     "Received invalid close reason. Sending acknowledgement and closing");
                 ec = send_close_ack(close::status::protocol_error,
                     "Invalid close reason");
@@ -2018,7 +2018,7 @@ void connection<config>::process_control_frame(typename config::message_type::pt
             s.str("");
             s << "Received close frame with code " << m_remote_close_code
               << " and reason " << m_remote_close_reason;
-            m_alog.write(log::alevel::devel,s.str());
+            m_alog->write(log::alevel::devel,s.str());
 
             ec = send_close_ack();
             if (ec) {
@@ -2026,7 +2026,7 @@ void connection<config>::process_control_frame(typename config::message_type::pt
             }
         } else if (m_state == session::state::closing && !m_was_clean) {
             // ack of our close
-            m_alog.write(log::alevel::devel, "Got acknowledgement of close");
+            m_alog->write(log::alevel::devel, "Got acknowledgement of close");
 
             m_was_clean = true;
 
@@ -2042,11 +2042,11 @@ void connection<config>::process_control_frame(typename config::message_type::pt
             }
         } else {
             // spurious, ignore
-            m_elog.write(log::elevel::devel, "Got close frame in wrong state");
+            m_elog->write(log::elevel::devel, "Got close frame in wrong state");
         }
     } else {
         // got an invalid control opcode
-        m_elog.write(log::elevel::devel, "Got control frame with invalid opcode");
+        m_elog->write(log::elevel::devel, "Got control frame with invalid opcode");
         // initiate protocol error shutdown
     }
 }
@@ -2062,7 +2062,7 @@ template <typename config>
 lib::error_code connection<config>::send_close_frame(close::status::value code,
     std::string const & reason, bool ack, bool terminal)
 {
-    m_alog.write(log::alevel::devel,"send_close_frame");
+    m_alog->write(log::alevel::devel,"send_close_frame");
 
     // check for special codes
 
@@ -2073,24 +2073,24 @@ lib::error_code connection<config>::send_close_frame(close::status::value code,
     // send blank info. If it is an ack then echo the close information from
     // the remote endpoint.
     if (config::silent_close) {
-        m_alog.write(log::alevel::devel,"closing silently");
+        m_alog->write(log::alevel::devel,"closing silently");
         m_local_close_code = close::status::no_status;
         m_local_close_reason.clear();
     } else if (code != close::status::blank) {
-        m_alog.write(log::alevel::devel,"closing with specified codes");
+        m_alog->write(log::alevel::devel,"closing with specified codes");
         m_local_close_code = code;
         m_local_close_reason = reason;
     } else if (!ack) {
-        m_alog.write(log::alevel::devel,"closing with no status code");
+        m_alog->write(log::alevel::devel,"closing with no status code");
         m_local_close_code = close::status::no_status;
         m_local_close_reason.clear();
     } else if (m_remote_close_code == close::status::no_status) {
-        m_alog.write(log::alevel::devel,
+        m_alog->write(log::alevel::devel,
             "acknowledging a no-status close with normal code");
         m_local_close_code = close::status::normal;
         m_local_close_reason.clear();
     } else {
-        m_alog.write(log::alevel::devel,"acknowledging with remote codes");
+        m_alog->write(log::alevel::devel,"acknowledging with remote codes");
         m_local_close_code = m_remote_close_code;
         m_local_close_reason = m_remote_close_reason;
     }
@@ -2098,7 +2098,7 @@ lib::error_code connection<config>::send_close_frame(close::status::value code,
     std::stringstream s;
     s << "Closing with code: " << m_local_close_code << ", and reason: "
       << m_local_close_reason;
-    m_alog.write(log::alevel::devel,s.str());
+    m_alog->write(log::alevel::devel,s.str());
 
     message_ptr msg = m_msg_manager->get_message();
     if (!msg) {
@@ -2213,11 +2213,11 @@ void connection<config>::write_push(typename config::message_type::ptr msg)
     m_send_buffer_size += msg->get_payload().size();
     m_send_queue.push(msg);
 
-    if (m_alog.static_test(log::alevel::devel)) {
+    if (m_alog->static_test(log::alevel::devel)) {
         std::stringstream s;
         s << "write_push: message count: " << m_send_queue.size()
           << " buffer size: " << m_send_buffer_size;
-        m_alog.write(log::alevel::devel,s.str());
+        m_alog->write(log::alevel::devel,s.str());
     }
 }
 
@@ -2235,11 +2235,11 @@ typename config::message_type::ptr connection<config>::write_pop()
     m_send_buffer_size -= msg->get_payload().size();
     m_send_queue.pop();
 
-    if (m_alog.static_test(log::alevel::devel)) {
+    if (m_alog->static_test(log::alevel::devel)) {
         std::stringstream s;
         s << "write_pop: message count: " << m_send_queue.size()
           << " buffer size: " << m_send_buffer_size;
-        m_alog.write(log::alevel::devel,s.str());
+        m_alog->write(log::alevel::devel,s.str());
     }
     return msg;
 }
@@ -2282,7 +2282,7 @@ void connection<config>::log_open_result()
     // Status code
     s << m_response.get_status_code();
 
-    m_alog.write(log::alevel::connect,s.str());
+    m_alog->write(log::alevel::connect,s.str());
 }
 
 template <typename config>
@@ -2296,7 +2296,7 @@ void connection<config>::log_close_result()
       << "] remote:[" << m_remote_close_code
       << (m_remote_close_reason.empty() ? "" : ","+m_remote_close_reason) << "]";
 
-    m_alog.write(log::alevel::disconnect,s.str());
+    m_alog->write(log::alevel::disconnect,s.str());
 }
 
 template <typename config>
@@ -2335,7 +2335,7 @@ void connection<config>::log_fail_result()
     // WebSocket++ error code & reason
     s << " " << m_ec << " " << m_ec.message();
 
-    m_alog.write(log::alevel::fail,s.str());
+    m_alog->write(log::alevel::fail,s.str());
 }
 
 template <typename config>
@@ -2343,7 +2343,7 @@ void connection<config>::log_http_result() {
     std::stringstream s;
 
     if (processor::is_websocket_handshake(m_request)) {
-        m_alog.write(log::alevel::devel,"Call to log_http_result for WebSocket");
+        m_alog->write(log::alevel::devel,"Call to log_http_result for WebSocket");
         return;
     }  
 
@@ -2364,7 +2364,7 @@ void connection<config>::log_http_result() {
         s << " \"" << utility::string_replace_all(ua,"\"","\\\"") << "\" ";
     }
 
-    m_alog.write(log::alevel::http,s.str());
+    m_alog->write(log::alevel::http,s.str());
 }
 
 } // namespace websocketpp

--- a/websocketpp/impl/endpoint_impl.hpp
+++ b/websocketpp/impl/endpoint_impl.hpp
@@ -35,7 +35,7 @@ namespace websocketpp {
 template <typename connection, typename config>
 typename endpoint<connection,config>::connection_ptr
 endpoint<connection,config>::create_connection() {
-    m_alog.write(log::alevel::devel,"create_connection");
+    m_alog->write(log::alevel::devel,"create_connection");
     //scoped_lock_type lock(m_state_lock);
 
     /*if (m_state == STOPPING || m_state == STOPPED) {
@@ -45,7 +45,7 @@ endpoint<connection,config>::create_connection() {
     //scoped_lock_type guard(m_mutex);
     // Create a connection on the heap and manage it using a shared pointer
     connection_ptr con = lib::make_shared<connection_type>(m_is_server,
-        m_user_agent, lib::ref(m_alog), lib::ref(m_elog), lib::ref(m_rng));
+        m_user_agent, m_alog, m_elog, lib::ref(m_rng));
 
     connection_weak_ptr w(con);
 
@@ -85,7 +85,7 @@ endpoint<connection,config>::create_connection() {
 
     ec = transport_type::init(con);
     if (ec) {
-        m_elog.write(log::elevel::fatal,ec.message());
+        m_elog->write(log::elevel::fatal,ec.message());
         return connection_ptr();
     }
 
@@ -98,7 +98,7 @@ void endpoint<connection,config>::interrupt(connection_hdl hdl, lib::error_code 
     connection_ptr con = get_con_from_hdl(hdl,ec);
     if (ec) {return;}
 
-    m_alog.write(log::alevel::devel,"Interrupting connection");
+    m_alog->write(log::alevel::devel,"Interrupting connection");
 
     ec = con->interrupt();
 }

--- a/websocketpp/roles/client_endpoint.hpp
+++ b/websocketpp/roles/client_endpoint.hpp
@@ -71,7 +71,7 @@ public:
 
     explicit client() : endpoint_type(false)
     {
-        endpoint_type::m_alog.write(log::alevel::devel, "client constructor");
+        endpoint_type::m_alog->write(log::alevel::devel, "client constructor");
     }
 
     /// Get a new connection
@@ -157,10 +157,10 @@ private:
         if (ec) {
             con->terminate(ec);
 
-            endpoint_type::m_elog.write(log::elevel::rerror,
+            endpoint_type::m_elog->write(log::elevel::rerror,
                     "handle_connect error: "+ec.message());
         } else {
-            endpoint_type::m_alog.write(log::alevel::connect,
+            endpoint_type::m_alog->write(log::alevel::connect,
                 "Successful connection");
 
             con->start();

--- a/websocketpp/roles/server_endpoint.hpp
+++ b/websocketpp/roles/server_endpoint.hpp
@@ -68,7 +68,7 @@ public:
 
     explicit server() : endpoint_type(true)
     {
-        endpoint_type::m_alog.write(log::alevel::devel, "server constructor");
+        endpoint_type::m_alog->write(log::alevel::devel, "server constructor");
     }
 
     /// Destructor
@@ -163,10 +163,10 @@ public:
             con->terminate(ec);
 
             if (ec == error::operation_canceled) {
-                endpoint_type::m_elog.write(log::elevel::info,
+                endpoint_type::m_elog->write(log::elevel::info,
                     "handle_accept error: "+ec.message());
             } else {
-                endpoint_type::m_elog.write(log::elevel::rerror,
+                endpoint_type::m_elog->write(log::elevel::rerror,
                     "handle_accept error: "+ec.message());
             }
         } else {
@@ -176,10 +176,10 @@ public:
         lib::error_code start_ec;
         start_accept(start_ec);
         if (start_ec == error::async_accept_not_listening) {
-            endpoint_type::m_elog.write(log::elevel::info,
+            endpoint_type::m_elog->write(log::elevel::info,
                 "Stopping acceptance of new connections because the underlying transport is no longer listening.");
         } else if (start_ec) {
-            endpoint_type::m_elog.write(log::elevel::rerror,
+            endpoint_type::m_elog->write(log::elevel::rerror,
                 "Restarting async_accept loop failed: "+ec.message());
         }
     }

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -98,12 +98,12 @@ public:
     friend class endpoint<config>;
 
     // generate and manage our own io_service
-    explicit connection(bool is_server, alog_type & alog, elog_type & elog)
+    explicit connection(bool is_server, const lib::shared_ptr<alog_type> & alog, const lib::shared_ptr<elog_type> & elog)
       : m_is_server(is_server)
       , m_alog(alog)
       , m_elog(elog)
     {
-        m_alog.write(log::alevel::devel,"asio con transport constructor");
+        m_alog->write(log::alevel::devel,"asio con transport constructor");
     }
 
     /// Get a shared pointer to this component
@@ -284,7 +284,7 @@ public:
         std::string ret = socket_con_type::get_remote_endpoint(ec);
 
         if (ec) {
-            m_elog.write(log::elevel::info,ret);
+            m_elog->write(log::elevel::info,ret);
             return "Unknown";
         } else {
             return ret;
@@ -408,8 +408,8 @@ public:
      */
 protected:
     void init(init_handler callback) {
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,"asio connection init");
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,"asio connection init");
         }
 
         // TODO: pre-init timeout. Right now no implemented socket policies
@@ -472,8 +472,8 @@ protected:
     }
 
     void handle_pre_init(init_handler callback, lib::error_code const & ec) {
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,"asio connection handle pre_init");
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,"asio connection handle pre_init");
         }
 
         if (m_tcp_pre_init_handler) {
@@ -494,8 +494,8 @@ protected:
     }
 
     void post_init(init_handler callback) {
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,"asio connection post_init");
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,"asio connection post_init");
         }
 
         timer_ptr post_timer;
@@ -540,7 +540,7 @@ protected:
 
         if (ec) {
             if (ec == transport::error::operation_aborted) {
-                m_alog.write(log::alevel::devel,
+                m_alog->write(log::alevel::devel,
                     "asio post init timer cancelled");
                 return;
             }
@@ -555,7 +555,7 @@ protected:
             }
         }
 
-        m_alog.write(log::alevel::devel, "Asio transport post-init timed out");
+        m_alog->write(log::alevel::devel, "Asio transport post-init timed out");
         cancel_socket_checked();
         callback(ret_ec);
     }
@@ -575,7 +575,7 @@ protected:
         if (ec == transport::error::operation_aborted ||
             (post_timer && lib::asio::is_neg(post_timer->expires_from_now())))
         {
-            m_alog.write(log::alevel::devel,"post_init cancelled");
+            m_alog->write(log::alevel::devel,"post_init cancelled");
             return;
         }
 
@@ -583,8 +583,8 @@ protected:
             post_timer->cancel();
         }
 
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,"asio connection handle_post_init");
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,"asio connection handle_post_init");
         }
 
         if (m_tcp_post_init_handler) {
@@ -595,12 +595,12 @@ protected:
     }
 
     void proxy_write(init_handler callback) {
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,"asio connection proxy_write");
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,"asio connection proxy_write");
         }
 
         if (!m_proxy_data) {
-            m_elog.write(log::elevel::library,
+            m_elog->write(log::elevel::library,
                 "assertion failed: !m_proxy_data in asio::connection::proxy_write");
             callback(make_error_code(error::general));
             return;
@@ -611,7 +611,7 @@ protected:
         m_bufs.push_back(lib::asio::buffer(m_proxy_data->write_buf.data(),
                                            m_proxy_data->write_buf.size()));
 
-        m_alog.write(log::alevel::devel,m_proxy_data->write_buf);
+        m_alog->write(log::alevel::devel,m_proxy_data->write_buf);
 
         // Set a timer so we don't wait forever for the proxy to respond
         m_proxy_data->timer = this->set_timer(
@@ -651,14 +651,14 @@ protected:
     void handle_proxy_timeout(init_handler callback, lib::error_code const & ec)
     {
         if (ec == transport::error::operation_aborted) {
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 "asio handle_proxy_write timer cancelled");
             return;
         } else if (ec) {
             log_err(log::elevel::devel,"asio handle_proxy_write",ec);
             callback(ec);
         } else {
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 "asio handle_proxy_write timer expired");
             cancel_socket_checked();
             callback(make_error_code(transport::error::timeout));
@@ -668,8 +668,8 @@ protected:
     void handle_proxy_write(init_handler callback,
         lib::asio::error_code const & ec)
     {
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,
                 "asio connection handle_proxy_write");
         }
 
@@ -681,7 +681,7 @@ protected:
         if (ec == lib::asio::error::operation_aborted ||
             lib::asio::is_neg(m_proxy_data->timer->expires_from_now()))
         {
-            m_elog.write(log::elevel::devel,"write operation aborted");
+            m_elog->write(log::elevel::devel,"write operation aborted");
             return;
         }
 
@@ -696,12 +696,12 @@ protected:
     }
 
     void proxy_read(init_handler callback) {
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,"asio connection proxy_read");
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,"asio connection proxy_read");
         }
 
         if (!m_proxy_data) {
-            m_elog.write(log::elevel::library,
+            m_elog->write(log::elevel::library,
                 "assertion failed: !m_proxy_data in asio::connection::proxy_read");
             m_proxy_data->timer->cancel();
             callback(make_error_code(error::general));
@@ -742,8 +742,8 @@ protected:
     void handle_proxy_read(init_handler callback,
         lib::asio::error_code const & ec, size_t)
     {
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,
                 "asio connection handle_proxy_read");
         }
 
@@ -753,7 +753,7 @@ protected:
         if (ec == lib::asio::error::operation_aborted ||
             lib::asio::is_neg(m_proxy_data->timer->expires_from_now()))
         {
-            m_elog.write(log::elevel::devel,"read operation aborted");
+            m_elog->write(log::elevel::devel,"read operation aborted");
             return;
         }
 
@@ -761,12 +761,12 @@ protected:
         m_proxy_data->timer->cancel();
 
         if (ec) {
-            m_elog.write(log::elevel::info,
+            m_elog->write(log::elevel::info,
                 "asio handle_proxy_read error: "+ec.message());
             callback(make_error_code(error::pass_through));
         } else {
             if (!m_proxy_data) {
-                m_elog.write(log::elevel::library,
+                m_elog->write(log::elevel::library,
                     "assertion failed: !m_proxy_data in asio::connection::handle_proxy_read");
                 callback(make_error_code(error::general));
                 return;
@@ -783,7 +783,7 @@ protected:
                 return;
             }
 
-            m_alog.write(log::alevel::devel,m_proxy_data->res.raw());
+            m_alog->write(log::alevel::devel,m_proxy_data->res.raw());
 
             if (m_proxy_data->res.get_status_code() != http::status_code::ok) {
                 // got an error response back
@@ -795,7 +795,7 @@ protected:
                   << " ("
                   << m_proxy_data->res.get_status_msg()
                   << ")";
-                m_elog.write(log::elevel::info,s.str());
+                m_elog->write(log::elevel::info,s.str());
                 callback(make_error_code(error::proxy_failed));
                 return;
             }
@@ -820,16 +820,16 @@ protected:
     void async_read_at_least(size_t num_bytes, char *buf, size_t len,
         read_handler handler)
     {
-        if (m_alog.static_test(log::alevel::devel)) {
+        if (m_alog->static_test(log::alevel::devel)) {
             std::stringstream s;
             s << "asio async_read_at_least: " << num_bytes;
-            m_alog.write(log::alevel::devel,s.str());
+            m_alog->write(log::alevel::devel,s.str());
         }
 
         // TODO: safety vs speed ?
         // maybe move into an if devel block
         /*if (num_bytes > len) {
-            m_elog.write(log::elevel::devel,
+            m_elog->write(log::elevel::devel,
                 "asio async_read_at_least error::invalid_num_bytes");
             handler(make_error_code(transport::error::invalid_num_bytes),
                 size_t(0));
@@ -871,7 +871,7 @@ protected:
     void handle_async_read(read_handler handler, lib::asio::error_code const & ec,
         size_t bytes_transferred)
     {
-        m_alog.write(log::alevel::devel, "asio con handle_async_read");
+        m_alog->write(log::alevel::devel, "asio con handle_async_read");
 
         // translate asio error codes into more lib::error_codes
         lib::error_code tec;
@@ -897,7 +897,7 @@ protected:
         } else {
             // This can happen in cases where the connection is terminated while
             // the transport is waiting on a read.
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 "handle_async_read called with null read handler");
         }
     }
@@ -989,7 +989,7 @@ protected:
         } else {
             // This can happen in cases where the connection is terminated while
             // the transport is waiting on a read.
-            m_alog.write(log::alevel::devel,
+            m_alog->write(log::alevel::devel,
                 "handle_async_write called with null write handler");
         }
     }
@@ -1034,8 +1034,8 @@ protected:
 
     /// close and clean up the underlying socket
     void async_shutdown(shutdown_handler callback) {
-        if (m_alog.static_test(log::alevel::devel)) {
-            m_alog.write(log::alevel::devel,"asio connection async_shutdown");
+        if (m_alog->static_test(log::alevel::devel)) {
+            m_alog->write(log::alevel::devel,"asio connection async_shutdown");
         }
 
         timer_ptr shutdown_timer;
@@ -1074,7 +1074,7 @@ protected:
 
         if (ec) {
             if (ec == transport::error::operation_aborted) {
-                m_alog.write(log::alevel::devel,
+                m_alog->write(log::alevel::devel,
                     "asio socket shutdown timer cancelled");
                 return;
             }
@@ -1085,7 +1085,7 @@ protected:
             ret_ec = make_error_code(transport::error::timeout);
         }
 
-        m_alog.write(log::alevel::devel,
+        m_alog->write(log::alevel::devel,
             "Asio transport socket shutdown timed out");
         cancel_socket_checked();
         callback(ret_ec);
@@ -1097,7 +1097,7 @@ protected:
         if (ec == lib::asio::error::operation_aborted ||
             lib::asio::is_neg(shutdown_timer->expires_from_now()))
         {
-            m_alog.write(log::alevel::devel,"async_shutdown cancelled");
+            m_alog->write(log::alevel::devel,"async_shutdown cancelled");
             return;
         }
 
@@ -1120,7 +1120,7 @@ protected:
                     // TLS short read at this point is somewhat expected if both
                     // sides try and end the connection at the same time or if
                     // SSLv2 is being used. In general there is nothing that can
-                    // be done here other than a low level development log.
+                    // be done here other than a low level development log->
                 } else {
                     // all other errors are effectively pass through errors of
                     // some sort so print some detail on the info channel for
@@ -1129,8 +1129,8 @@ protected:
                 }
             }
         } else {
-            if (m_alog.static_test(log::alevel::devel)) {
-                m_alog.write(log::alevel::devel,
+            if (m_alog->static_test(log::alevel::devel)) {
+                m_alog->write(log::alevel::devel,
                     "asio con handle_async_shutdown");
             }
         }
@@ -1143,7 +1143,7 @@ protected:
         if (cec) {
             if (cec == lib::asio::error::operation_not_supported) {
                 // cancel not supported on this OS, ignore and log at dev level
-                m_alog.write(log::alevel::devel, "socket cancel not supported");
+                m_alog->write(log::alevel::devel, "socket cancel not supported");
             } else {
                 log_err(log::elevel::warn, "socket cancel failed", cec);
             }
@@ -1156,13 +1156,13 @@ private:
     void log_err(log::level l, const char * msg, const error_type & ec) {
         std::stringstream s;
         s << msg << " error: " << ec << " (" << ec.message() << ")";
-        m_elog.write(l,s.str());
+        m_elog->write(l,s.str());
     }
 
     // static settings
     const bool m_is_server;
-    alog_type& m_alog;
-    elog_type& m_elog;
+    lib::shared_ptr<alog_type> m_alog;
+    lib::shared_ptr<elog_type> m_elog;
 
     struct proxy_data {
         proxy_data() : timeout_proxy(config::timeout_proxy) {}

--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -743,7 +743,7 @@ public:
     void async_accept(transport_con_ptr tcon, accept_handler callback,
         lib::error_code & ec)
     {
-        if (m_state != LISTENING) {
+        if (m_state != LISTENING || !m_acceptor) {
             using websocketpp::error::make_error_code;
             ec = make_error_code(websocketpp::error::async_accept_not_listening);
             return;
@@ -795,7 +795,7 @@ protected:
      * haven't been constructed yet, and cannot be used in the transport
      * destructor as they will have been destroyed by then.
      */
-    void init_logging(alog_type* a, elog_type* e) {
+    void init_logging(const lib::shared_ptr<alog_type>& a, const lib::shared_ptr<elog_type>& e) {
         m_alog = a;
         m_elog = e;
     }
@@ -1133,8 +1133,8 @@ private:
     int                 m_listen_backlog;
     bool                m_reuse_addr;
 
-    elog_type* m_elog;
-    alog_type* m_alog;
+    lib::shared_ptr<elog_type> m_elog;
+    lib::shared_ptr<alog_type> m_alog;
 
     // Transport state
     state               m_state;

--- a/websocketpp/transport/base/endpoint.hpp
+++ b/websocketpp/transport/base/endpoint.hpp
@@ -59,7 +59,7 @@ namespace websocketpp {
  * `connection_hdl` and any error that occurred.
  *
  * **init_logging**
- * `void init_logging(alog_type * a, elog_type * e)`\n
+ * `void init_logging(const lib::shared_ptr<alog_type>& a, const lib::shared_ptr<elog_type>& e)`\n
  * Called once after construction to provide pointers to the endpoint's access
  * and error loggers. These may be stored and used to log messages or ignored.
  */

--- a/websocketpp/transport/debug/connection.hpp
+++ b/websocketpp/transport/debug/connection.hpp
@@ -73,10 +73,10 @@ public:
 
     typedef lib::shared_ptr<timer> timer_ptr;
 
-    explicit connection(bool is_server, alog_type & alog, elog_type & elog)
+    explicit connection(bool is_server, const lib::shared_ptr<alog_type> & alog, const lib::shared_ptr<elog_type> & elog)
       : m_reading(false), m_is_server(is_server), m_alog(alog), m_elog(elog)
     {
-        m_alog.write(log::alevel::devel,"debug con transport constructor");
+        m_alog->write(log::alevel::devel,"debug con transport constructor");
     }
 
     /// Get a shared pointer to this component
@@ -166,7 +166,7 @@ public:
      * needed.
      */
     timer_ptr set_timer(long, timer_handler handler) {
-        m_alog.write(log::alevel::devel,"debug connection set timer");
+        m_alog->write(log::alevel::devel,"debug connection set timer");
         m_timer_handler = handler;
         return timer_ptr();
     }
@@ -215,7 +215,7 @@ protected:
      * @param handler The `init_handler` to call when initialization is done
      */
     void init(init_handler handler) {
-        m_alog.write(log::alevel::devel,"debug connection init");
+        m_alog->write(log::alevel::devel,"debug connection init");
         handler(lib::error_code());
     }
 
@@ -248,7 +248,7 @@ protected:
     {
         std::stringstream s;
         s << "debug_con async_read_at_least: " << num_bytes;
-        m_alog.write(log::alevel::devel,s.str());
+        m_alog->write(log::alevel::devel,s.str());
 
         if (num_bytes > len) {
             handler(make_error_code(error::invalid_num_bytes),size_t(0));
@@ -286,7 +286,7 @@ protected:
      * @param handler Callback to invoke with operation status.
      */
     void async_write(char const *, size_t, write_handler handler) {
-        m_alog.write(log::alevel::devel,"debug_con async_write");
+        m_alog->write(log::alevel::devel,"debug_con async_write");
         m_write_handler = handler;
     }
 
@@ -302,7 +302,7 @@ protected:
      * @param handler Callback to invoke with operation status.
      */
     void async_write(std::vector<buffer> const &, write_handler handler) {
-        m_alog.write(log::alevel::devel,"debug_con async_write buffer list");
+        m_alog->write(log::alevel::devel,"debug_con async_write buffer list");
         m_write_handler = handler;
     }
 
@@ -337,10 +337,10 @@ protected:
     }
     
     size_t read_some_impl(char const * buf, size_t len) {
-        m_alog.write(log::alevel::devel,"debug_con read_some");
+        m_alog->write(log::alevel::devel,"debug_con read_some");
 
         if (!m_reading) {
-            m_elog.write(log::elevel::devel,"write while not reading");
+            m_elog->write(log::elevel::devel,"write while not reading");
             return 0;
         }
 
@@ -399,8 +399,8 @@ private:
     bool            m_reading;
     bool const      m_is_server;
     bool            m_is_secure;
-    alog_type &     m_alog;
-    elog_type &     m_elog;
+    lib::shared_ptr<alog_type>     m_alog;
+    lib::shared_ptr<elog_type>     m_elog;
     std::string     m_remote_endpoint;
 };
 

--- a/websocketpp/transport/debug/endpoint.hpp
+++ b/websocketpp/transport/debug/endpoint.hpp
@@ -103,7 +103,7 @@ protected:
      * @param a A pointer to the access logger to use.
      * @param e A pointer to the error logger to use.
      */
-    void init_logging(alog_type *, elog_type *) {}
+    void init_logging(lib::shared_ptr<alog_type>, lib::shared_ptr<elog_type>) {}
 
     /// Initiate a new connection
     /**

--- a/websocketpp/transport/iostream/connection.hpp
+++ b/websocketpp/transport/iostream/connection.hpp
@@ -77,7 +77,7 @@ public:
 
     typedef lib::shared_ptr<timer> timer_ptr;
 
-    explicit connection(bool is_server, alog_type & alog, elog_type & elog)
+    explicit connection(bool is_server, const lib::shared_ptr<alog_type> & alog, const lib::shared_ptr<elog_type> & elog)
       : m_output_stream(NULL)
       , m_reading(false)
       , m_is_server(is_server)
@@ -86,7 +86,7 @@ public:
       , m_elog(elog)
       , m_remote_endpoint("iostream transport")
     {
-        m_alog.write(log::alevel::devel,"iostream con transport constructor");
+        m_alog->write(log::alevel::devel,"iostream con transport constructor");
     }
 
     /// Get a shared pointer to this component
@@ -408,7 +408,7 @@ protected:
      * @param handler The `init_handler` to call when initialization is done
      */
     void init(init_handler handler) {
-        m_alog.write(log::alevel::devel,"iostream connection init");
+        m_alog->write(log::alevel::devel,"iostream connection init");
         handler(lib::error_code());
     }
 
@@ -441,7 +441,7 @@ protected:
     {
         std::stringstream s;
         s << "iostream_con async_read_at_least: " << num_bytes;
-        m_alog.write(log::alevel::devel,s.str());
+        m_alog->write(log::alevel::devel,s.str());
 
         if (num_bytes > len) {
             handler(make_error_code(error::invalid_num_bytes),size_t(0));
@@ -487,7 +487,7 @@ protected:
     void async_write(char const * buf, size_t len, transport::write_handler
         handler)
     {
-        m_alog.write(log::alevel::devel,"iostream_con async_write");
+        m_alog->write(log::alevel::devel,"iostream_con async_write");
         // TODO: lock transport state?
 
         lib::error_code ec;
@@ -527,7 +527,7 @@ protected:
     void async_write(std::vector<buffer> const & bufs, transport::write_handler
         handler)
     {
-        m_alog.write(log::alevel::devel,"iostream_con async_write buffer list");
+        m_alog->write(log::alevel::devel,"iostream_con async_write buffer list");
         // TODO: lock transport state?
 
         lib::error_code ec;
@@ -601,18 +601,18 @@ protected:
     }
 private:
     void read(std::istream &in) {
-        m_alog.write(log::alevel::devel,"iostream_con read");
+        m_alog->write(log::alevel::devel,"iostream_con read");
 
         while (in.good()) {
             if (!m_reading) {
-                m_elog.write(log::elevel::devel,"write while not reading");
+                m_elog->write(log::elevel::devel,"write while not reading");
                 break;
             }
 
             in.read(m_buf+m_cursor,static_cast<std::streamsize>(m_len-m_cursor));
 
             if (in.gcount() == 0) {
-                m_elog.write(log::elevel::devel,"read zero bytes");
+                m_elog->write(log::elevel::devel,"read zero bytes");
                 break;
             }
 
@@ -632,10 +632,10 @@ private:
     }
 
     size_t read_some_impl(char const * buf, size_t len) {
-        m_alog.write(log::alevel::devel,"iostream_con read_some");
+        m_alog->write(log::alevel::devel,"iostream_con read_some");
 
         if (!m_reading) {
-            m_elog.write(log::elevel::devel,"write while not reading");
+            m_elog->write(log::elevel::devel,"write while not reading");
             return 0;
         }
 
@@ -694,8 +694,8 @@ private:
     bool            m_reading;
     bool const      m_is_server;
     bool            m_is_secure;
-    alog_type &     m_alog;
-    elog_type &     m_elog;
+    lib::shared_ptr<alog_type>     m_alog;
+    lib::shared_ptr<elog_type>     m_elog;
     std::string     m_remote_endpoint;
 
     // This lock ensures that only one thread can edit read data for this

--- a/websocketpp/transport/iostream/endpoint.hpp
+++ b/websocketpp/transport/iostream/endpoint.hpp
@@ -168,7 +168,7 @@ protected:
      * @param a A pointer to the access logger to use.
      * @param e A pointer to the error logger to use.
      */
-    void init_logging(alog_type * a, elog_type * e) {
+    void init_logging(lib::shared_ptr<alog_type> a, lib::shared_ptr<elog_type> e) {
         m_elog = e;
         m_alog = a;
     }
@@ -209,8 +209,8 @@ private:
     shutdown_handler m_shutdown_handler;
     write_handler   m_write_handler;
     
-    elog_type *     m_elog;
-    alog_type *     m_alog;
+    lib::shared_ptr<elog_type>     m_elog;
+    lib::shared_ptr<alog_type>     m_alog;
     bool            m_is_secure;
 };
 

--- a/websocketpp/transport/stub/connection.hpp
+++ b/websocketpp/transport/stub/connection.hpp
@@ -72,10 +72,10 @@ public:
 
     typedef lib::shared_ptr<timer> timer_ptr;
 
-    explicit connection(bool is_server, alog_type & alog, elog_type & elog)
+    explicit connection(bool is_server, const lib::shared_ptr<alog_type> & alog, const lib::shared_ptr<elog_type> & elog)
       : m_alog(alog), m_elog(elog)
     {
-        m_alog.write(log::alevel::devel,"stub con transport constructor");
+        m_alog->write(log::alevel::devel,"stub con transport constructor");
     }
 
     /// Get a shared pointer to this component
@@ -175,7 +175,7 @@ protected:
      * @param handler The `init_handler` to call when initialization is done
      */
     void init(init_handler handler) {
-        m_alog.write(log::alevel::devel,"stub connection init");
+        m_alog->write(log::alevel::devel,"stub connection init");
         handler(make_error_code(error::not_implemented));
     }
 
@@ -206,7 +206,7 @@ protected:
     void async_read_at_least(size_t num_bytes, char * buf, size_t len,
         read_handler handler)
     {
-        m_alog.write(log::alevel::devel, "stub_con async_read_at_least");
+        m_alog->write(log::alevel::devel, "stub_con async_read_at_least");
         handler(make_error_code(error::not_implemented), 0);
     }
 
@@ -223,7 +223,7 @@ protected:
      * @param handler Callback to invoke with operation status.
      */
     void async_write(char const * buf, size_t len, write_handler handler) {
-        m_alog.write(log::alevel::devel,"stub_con async_write");
+        m_alog->write(log::alevel::devel,"stub_con async_write");
         handler(make_error_code(error::not_implemented));
     }
 
@@ -239,7 +239,7 @@ protected:
      * @param handler Callback to invoke with operation status.
      */
     void async_write(std::vector<buffer> const & bufs, write_handler handler) {
-        m_alog.write(log::alevel::devel,"stub_con async_write buffer list");
+        m_alog->write(log::alevel::devel,"stub_con async_write buffer list");
         handler(make_error_code(error::not_implemented));
     }
 
@@ -274,8 +274,8 @@ protected:
     }
 private:
     // member variables!
-    alog_type & m_alog;
-    elog_type & m_elog;
+    lib::shared_ptr<alog_type> m_alog;
+    lib::shared_ptr<elog_type> m_elog;
 };
 
 


### PR DESCRIPTION
This change fixes a shutdown crash occuring when using an
external io_service to drive a websocketpp server. The crash
itself is reproduced by the following code:

```

int main(int argc, const char * argv[])
{
    boost::asio::io_service ioService;
        std::unique_ptr<boost::asio::io_service::work> ioServiceWork(new boost::asio::io_service::work(ioService));
            std::thread ioServiceThread(boost::bind(&boost::asio::io_service::run, &ioService));

    {
        auto server = std::unique_ptr<websocketpp::server<websocketpp::config::asio>>(new websocketpp::server<websocketpp::config::asio>());
        server->init_asio(&ioService);
        server->listen(0);
        server->start_accept();

        server->stop();
    }

    ioServiceWork.reset();
    ioService.stop();
    ioServiceThread.join();

    return 0;
}
```

The cause of the crash is a dangling pointer to alog or elog objects in endpoints.
This is mitigated by storing logging objects as shared_ptrs. This ensures that
they are kept alive and able to log even if their owning structures have already
been deallocated.