### PR TITLE
Add Support for Authenticated Proxies (updated)

### DIFF
--- a/examples/scratch_server/scratch_server.cpp
+++ b/examples/scratch_server/scratch_server.cpp
@@ -27,6 +27,8 @@ struct deflate_config : public websocketpp::config::debug_core {
     typedef base::elog_type elog_type;
     
     typedef base::rng_type rng_type;
+
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
     
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
@@ -36,6 +38,7 @@ struct deflate_config : public websocketpp::config::debug_core {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint 
             socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config> 

--- a/test/http/proxy_authenticator.cpp
+++ b/test/http/proxy_authenticator.cpp
@@ -1,0 +1,245 @@
+#define BOOST_TEST_MODULE http_authenticator
+#include <boost/test/unit_test.hpp>
+
+#include <iostream>
+#include <string>
+
+#include <websocketpp/http/proxy_authenticator.hpp>
+
+BOOST_AUTO_TEST_CASE(is_token68_char) {
+    for (int i = 0x00; i <= 0xFF; i++)
+    {
+        bool expectedResult = false;
+
+        expectedResult = ::isalnum(i) ? true : expectedResult;
+
+        expectedResult = (i == '-') ? true : expectedResult;
+        expectedResult = (i == '.') ? true : expectedResult;
+        expectedResult = (i == '_') ? true : expectedResult;
+        expectedResult = (i == '~') ? true : expectedResult;
+        expectedResult = (i == '+') ? true : expectedResult;
+        expectedResult = (i == '/') ? true : expectedResult;
+        expectedResult = (i == '=') ? true : expectedResult;
+
+        BOOST_CHECK(websocketpp::http::proxy::auth_parser::is_token68_char((unsigned char)(i)) == expectedResult);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(auth_scheme_parser) {
+    // Valid Basic Auth - with quoted string
+    std::string auth_headers = "Basic realm=\"some realm with \\\"quoted string\\\"\",type=1";
+
+    websocketpp::http::proxy::auth_parser::AuthSchemes auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 1);
+    BOOST_CHECK(auth_schemes.front().is_basic());
+    BOOST_CHECK(auth_schemes.front().get_realm() == "some realm with \"quoted string\"");
+
+    // NTLM
+    auth_headers = "NTLM";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 1);
+    BOOST_CHECK(auth_schemes.front().is_ntlm());
+    BOOST_CHECK(auth_schemes.front().get_challenge().empty());
+
+    // NTLM with Challenge
+    auth_headers = "NTLM challengeString=";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 1);
+    BOOST_CHECK(auth_schemes.front().is_ntlm());
+    BOOST_CHECK(auth_schemes.front().get_challenge() == "challengeString=");
+
+    // Negotiate with Challenge
+    auth_headers = "neGotiate challengeString=";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 1);
+    BOOST_CHECK(auth_schemes.front().is_negotiate());
+    BOOST_CHECK(auth_schemes.front().get_challenge() == "challengeString=");
+
+    // Valid Basic Auth + NTLM (mixed case)
+    auth_headers = "baSic realm=\"some realm\",type=1,nTlm";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 2);
+    BOOST_CHECK(auth_schemes[0].is_basic());
+    BOOST_CHECK(auth_schemes[0].get_realm() == "some realm");
+    BOOST_CHECK(auth_schemes[1].is_ntlm());
+    BOOST_CHECK(auth_schemes[1].get_challenge().empty());
+
+    websocketpp::http::proxy::auth_parser::AuthScheme auth_scheme = websocketpp::http::proxy::auth_parser::select_auth_scheme(auth_headers);
+
+    BOOST_CHECK(auth_scheme.is_ntlm());
+    BOOST_CHECK(auth_scheme.get_challenge().empty());
+
+    // Digest + NTLM + Basic
+    auth_headers = "Digest, NTLM, baSic realm=\"some realm\",type=1";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 3);
+    BOOST_CHECK(auth_schemes[0].is_digest());
+    BOOST_CHECK(auth_schemes[1].is_ntlm());
+    BOOST_CHECK(auth_schemes[1].get_challenge().empty());
+    BOOST_CHECK(auth_schemes[2].is_basic());
+    BOOST_CHECK(auth_schemes[2].get_realm() == "some realm");
+
+    auth_scheme = websocketpp::http::proxy::auth_parser::select_auth_scheme(auth_headers);
+
+    BOOST_CHECK(auth_scheme.is_ntlm());
+    BOOST_CHECK(auth_scheme.get_challenge().empty());
+
+    // Digest + NTLM + Basic + Negotiate
+    auth_headers = "Digest, NTLM, baSic realm=\"some realm\",type=1, negotiate";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.size() == 4);
+    BOOST_CHECK(auth_schemes[0].is_digest());
+    BOOST_CHECK(auth_schemes[1].is_ntlm());
+    BOOST_CHECK(auth_schemes[1].get_challenge().empty());
+    BOOST_CHECK(auth_schemes[2].is_basic());
+    BOOST_CHECK(auth_schemes[2].get_realm() == "some realm");
+    BOOST_CHECK(auth_schemes[3].is_negotiate());
+    BOOST_CHECK(auth_schemes[3].get_challenge().empty());
+
+    auth_scheme = websocketpp::http::proxy::auth_parser::select_auth_scheme(auth_headers);
+
+    BOOST_CHECK(auth_scheme.is_negotiate());
+    BOOST_CHECK(auth_scheme.get_challenge().empty());
+
+    // Unknown Auth Scheme fails the parse for all schemes
+    auth_headers = "Digest, NTLM, Basic realm=\"some realm\",type=1, NegotiateX";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.empty());
+
+    // Empty Parameter value for a basic auth fails the parse
+    auth_headers = "Digest, NTLM, Basic realm=\"some realm\",type=, Negotiate";
+
+    auth_schemes = websocketpp::http::proxy::auth_parser::parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+    BOOST_CHECK(auth_schemes.empty());
+}
+
+class fake_security_context {
+public:
+    typedef websocketpp::lib::shared_ptr<fake_security_context> Ptr;
+    typedef std::function<void(Ptr)> ReportContext;
+
+    static ReportContext report_context;
+
+    static fake_security_context::Ptr build(const std::string& proxyName, const std::string& authScheme) {
+        fake_security_context::Ptr context = websocketpp::lib::make_shared<fake_security_context>(proxyName, authScheme);
+
+        if (report_context) {
+            report_context(context);
+        }
+
+        return context;
+    }
+
+    fake_security_context(const std::string& proxyName, const std::string& authScheme) {
+    }
+
+    bool nextAuthToken(const std::string& challenge) {
+        m_last_challenge = challenge;
+        return m_auth_token.empty() ? false : true;
+    }
+
+    std::string getUpdatedToken() const {
+        return m_auth_token;
+    }
+
+    std::string m_auth_token;
+    std::string m_last_challenge;
+};
+
+fake_security_context::ReportContext fake_security_context::report_context;
+
+BOOST_AUTO_TEST_CASE(proxy_authenticator_tests) {
+    //
+    // Setup interceptor to access the security_context object
+    //
+    std::string proxy_name("myProxy.com");
+
+    fake_security_context::Ptr security_context;
+    fake_security_context::report_context = [&security_context](fake_security_context::Ptr newContext) {
+        security_context = newContext;
+        newContext->m_auth_token = "Token1=";
+    };
+
+    // 
+    // Test an typical NTLM multi step challenge auth flow
+    //
+    {
+        security_context.reset();
+
+        websocketpp::http::proxy::proxy_authenticator<fake_security_context> proxy_authenticator(proxy_name);
+
+        BOOST_CHECK(!security_context);
+
+        BOOST_CHECK(proxy_authenticator.get_auth_token().empty());
+
+        std::string auth_headers = "NTLM challenge1=";
+
+        BOOST_CHECK(proxy_authenticator.next_token(auth_headers));
+        BOOST_CHECK(security_context);
+        BOOST_CHECK(security_context->m_last_challenge == "challenge1=");
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NTLM Token1=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token().empty());
+
+        security_context->m_auth_token = "Token2=";
+        auth_headers = "NTLM challenge2=";
+
+        BOOST_CHECK(proxy_authenticator.next_token(auth_headers));
+        BOOST_CHECK(security_context->m_last_challenge == "challenge2=");
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NTLM Token2=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token().empty());
+
+        proxy_authenticator.set_authenticated();
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NTLM Token2=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token() == "NTLM Token2=");
+    }
+
+    // 
+    // Negotiate Flow (same as NTLM, but we're checking case insensitive)
+    //
+    {
+        security_context.reset();
+
+        websocketpp::http::proxy::proxy_authenticator<fake_security_context> proxy_authenticator(proxy_name);
+
+        BOOST_CHECK(!security_context);
+
+        BOOST_CHECK(proxy_authenticator.get_auth_token().empty());
+
+        std::string auth_headers = "NeGoTiAtE challenge1=";
+
+        BOOST_CHECK(proxy_authenticator.next_token(auth_headers));
+        BOOST_CHECK(security_context);
+        BOOST_CHECK(security_context->m_last_challenge == "challenge1=");
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NeGoTiAtE Token1=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token().empty());
+
+        security_context->m_auth_token = "Token2=";
+        auth_headers = "Negotiate challenge2=";
+
+        BOOST_CHECK(proxy_authenticator.next_token(auth_headers));
+        BOOST_CHECK(security_context->m_last_challenge == "challenge2=");
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NeGoTiAtE Token2=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token().empty());
+
+        proxy_authenticator.set_authenticated();
+        BOOST_CHECK(proxy_authenticator.get_auth_token() == "NeGoTiAtE Token2=");
+        BOOST_CHECK(proxy_authenticator.get_authenticated_token() == "NeGoTiAtE Token2=");
+    }
+}
+

--- a/test/transport/asio/timers.cpp
+++ b/test/transport/asio/timers.cpp
@@ -49,6 +49,10 @@
 
 #include <boost/asio.hpp>
 
+// Proxy Authentication Policy
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 // Accept a connection, read data, and discard until EOF
 void run_dummy_server(int port) {
     using boost::asio::ip::tcp;
@@ -94,6 +98,7 @@ struct config {
     typedef websocketpp::http::parser::request request_type;
     typedef websocketpp::http::parser::response response_type;
     typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+    typedef websocketpp::http::proxy::proxy_authenticator<websocketpp::lib::security::SecurityContext> proxy_authenticator_type;
 
     static const bool enable_multithreading = true;
 

--- a/websocketpp/common/impl/security_context.hpp
+++ b/websocketpp/common/impl/security_context.hpp
@@ -31,6 +31,7 @@
 #define WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
 
 #include <websocketpp/common/memory.hpp>
+#include <websocketpp/common/string_utils.hpp>
 
 #ifdef _WIN32
 
@@ -106,7 +107,7 @@ namespace websocketpp {
 
                         std::string target;
 
-                        if (authScheme == "Negotiate")
+                        if (websocketpp::lib::string_utils::icompare(authScheme,"Negotiate"))
                             target = "http/" + proxyName; // Service Principle Name
 
                         if (challenge.empty())

--- a/websocketpp/common/impl/security_context.hpp
+++ b/websocketpp/common/impl/security_context.hpp
@@ -1,0 +1,225 @@
+/*
+* Copyright (c) 2016, Peter Thorson. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the WebSocket++ Project nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The initial version of this Security Context policy was contributed to the WebSocket++
+* project by Colie McGarry.
+*/
+
+#ifndef WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
+#define WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP
+
+#include <websocketpp/common/memory.hpp>
+
+#ifdef _WIN32
+
+#include <websocketpp/base64/base64.hpp>
+
+#define SECURITY_WIN32
+
+#include <sspi.h>
+
+#define SEC_SUCCESS(Status) ((Status) >= 0)
+
+#pragma comment(lib, "Secur32.lib")
+
+namespace websocketpp {
+    namespace lib {
+        namespace security {
+            namespace platform {
+                class SecurityContext
+                {
+                public:
+                    typedef lib::shared_ptr<SecurityContext> Ptr;
+
+                    static SecurityContext::Ptr build(const std::string& proxyName, const std::string& authScheme) {
+                        return  lib::make_shared<SecurityContext>(proxyName, authScheme);
+                    }
+
+                    SecurityContext(const std::string& proxyName, const std::string& authScheme) :
+                        proxyName(proxyName), authScheme(authScheme)
+                    {
+                        TimeStamp           Lifetime;
+                        SECURITY_STATUS     ss;
+
+                        ss = ::AcquireCredentialsHandleA(
+                            NULL,
+                            (SEC_CHAR *)authScheme.c_str(),
+                            SECPKG_CRED_OUTBOUND,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL,
+                            &hCred,
+                            &Lifetime);
+
+                        if (!(SEC_SUCCESS(ss)))
+                        {
+                            return;
+                        }
+
+                        freeCredentials = true;
+                    }
+                    ~SecurityContext()
+                    {
+                        if (freeCredentials) {
+                            ::FreeCredentialsHandle(&hCred);
+                        }
+                    }
+
+                    bool nextAuthToken(const std::string& challenge)
+                    {
+                        TimeStamp           Lifetime;
+                        SECURITY_STATUS     ss;
+                        SecBufferDesc       OutBuffDesc;
+                        SecBuffer           OutSecBuff;
+                        ULONG               ContextAttributes;
+
+                        OutBuffDesc.ulVersion = SECBUFFER_VERSION;
+                        OutBuffDesc.cBuffers = 1;
+                        OutBuffDesc.pBuffers = &OutSecBuff;
+
+                        OutSecBuff.cbBuffer = 0;
+                        OutSecBuff.BufferType = SECBUFFER_TOKEN;
+                        OutSecBuff.pvBuffer = 0;
+
+                        std::string target;
+
+                        if (authScheme == "Negotiate")
+                            target = "http/" + proxyName; // Service Principle Name
+
+                        if (challenge.empty())
+                        {
+                            ss = ::InitializeSecurityContextA(
+                                &hCred,
+                                NULL,
+                                (SEC_CHAR *)target.c_str(), //.c_str(), // pszTarget,
+                                ISC_REQ_ALLOCATE_MEMORY, //ISC_REQ_CONFIDENTIALITY ,
+                                0,
+                                SECURITY_NETWORK_DREP, //SECURITY_NATIVE_DREP,
+                                NULL,
+                                0,
+                                &hContext,
+                                &OutBuffDesc,
+                                &ContextAttributes,
+                                &Lifetime);
+                        }
+                        else
+                        {
+                            auto decodedChallenge = base64_decode(challenge);
+
+                            SecBufferDesc     InBuffDesc;
+                            SecBuffer         InSecBuff;
+
+                            InBuffDesc.ulVersion = 0;
+                            InBuffDesc.cBuffers = 1;
+                            InBuffDesc.pBuffers = &InSecBuff;
+
+                            InSecBuff.cbBuffer = (unsigned long)decodedChallenge.size();
+                            InSecBuff.BufferType = SECBUFFER_TOKEN;
+                            InSecBuff.pvBuffer = (BYTE *)&decodedChallenge[0];
+
+                            ss = ::InitializeSecurityContextA(
+                                &hCred,
+                                &hContext,
+                                (SEC_CHAR *)target.c_str(),
+                                ISC_REQ_ALLOCATE_MEMORY, //ISC_REQ_CONFIDENTIALITY ,
+                                0,
+                                SECURITY_NETWORK_DREP, // SECURITY_NATIVE_DREP,
+                                &InBuffDesc,
+                                0,
+                                &hContext,
+                                &OutBuffDesc,
+                                &ContextAttributes,
+                                &Lifetime);
+                        }
+
+                        if ((SEC_I_COMPLETE_NEEDED == ss) || (SEC_I_COMPLETE_AND_CONTINUE == ss))
+                        {
+                            ss = ::CompleteAuthToken(&hContext, &OutBuffDesc);
+
+                            if (!SEC_SUCCESS(ss))
+                            {
+                                return false;
+                            }
+                        }
+
+                        if (!OutSecBuff.pvBuffer)
+                        {
+                            return false;
+                        }
+
+                        updatedToken = base64_encode((const unsigned char*)OutSecBuff.pvBuffer, (size_t)OutSecBuff.cbBuffer);
+
+                        ::FreeContextBuffer(OutSecBuff.pvBuffer);
+
+                        bool continueAuthFlow = ((SEC_I_CONTINUE_NEEDED == ss) || (SEC_I_COMPLETE_AND_CONTINUE == ss));
+
+                        return continueAuthFlow;
+                    }
+
+                    std::string getUpdatedToken() const
+                    {
+                        return updatedToken;
+                    }
+
+                private:
+                    SecHandle         hContext;
+                    CredHandle        hCred;
+                    std::string       proxyName;
+                    std::string       authScheme;
+                    std::string       updatedToken;
+
+                    bool              freeCredentials = false;
+                };
+            }
+        }       // security
+    }           // lib
+}               // websocket
+
+#else // _WIN32
+
+namespace websocketpp {
+    namespace lib {
+        namespace security {
+            namespace platform {
+                class SecurityContext
+                {
+                public:
+                    typedef lib::shared_ptr<SecurityContext> Ptr;
+
+                    static Ptr build(const std::string& , const std::string& )  { return  Ptr(); }
+
+                    SecurityContext(const std::string& , const std::string& )   { }
+
+                    bool nextAuthToken(const std::string&)                      { return ""; }
+                    std::string getUpdatedToken() const                         { return ""; }
+               };
+            }
+        }       // security
+    }           // lib
+}               // websocket
+
+#endif // WIN32
+#endif // WEBSOCKETPP_COMMON_SECURITY_CONTEXT_WIN32_HPP

--- a/websocketpp/common/security_context.hpp
+++ b/websocketpp/common/security_context.hpp
@@ -25,52 +25,30 @@
  *
  */
 
-#ifndef WEBSOCKETPP_CONFIG_ASIO_CLIENT_HPP
-#define WEBSOCKETPP_CONFIG_ASIO_CLIENT_HPP
+#ifndef WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP
+#define WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP
 
-#include <websocketpp/config/core_client.hpp>
-#include <websocketpp/transport/asio/endpoint.hpp>
+#include <websocketpp/common/memory.hpp>
+
+#include <string>
 
 namespace websocketpp {
-namespace config {
+    namespace lib {
+        namespace security {
+            class SecurityContext
+            {
+            public:
+                typedef lib::shared_ptr<SecurityContext> Ptr;
 
-/// Client config with asio transport and TLS disabled
-struct asio_client : public core_client {
-    typedef asio_client type;
-    typedef core_client base;
+                static Ptr build(const std::string& , const std::string& )  { return  Ptr(); }
 
-    typedef base::concurrency_type concurrency_type;
+                SecurityContext(const std::string& , const std::string& )   { }
 
-    typedef base::request_type request_type;
-    typedef base::response_type response_type;
+                bool nextAuthToken(const std::string&)                      { return ""; }
+                std::string getUpdatedToken() const                         { return ""; }
+            };
+        }       // security
+    }           // lib
+}               // websocket
 
-    typedef base::message_type message_type;
-    typedef base::con_msg_manager_type con_msg_manager_type;
-    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
-
-    typedef base::alog_type alog_type;
-    typedef base::elog_type elog_type;
-
-    typedef base::rng_type rng_type;
-
-    typedef base::proxy_authenticator_type proxy_authenticator_type;
-
-    struct transport_config : public base::transport_config {
-        typedef type::concurrency_type concurrency_type;
-        typedef type::alog_type alog_type;
-        typedef type::elog_type elog_type;
-        typedef type::request_type request_type;
-        typedef type::response_type response_type;
-        typedef websocketpp::transport::asio::basic_socket::endpoint
-            socket_type;
-        typedef type::proxy_authenticator_type proxy_authenticator_type;
-    };
-
-    typedef websocketpp::transport::asio::endpoint<transport_config>
-        transport_type;
-};
-
-} // namespace config
-} // namespace websocketpp
-
-#endif // WEBSOCKETPP_CONFIG_ASIO_CLIENT_HPP
+#endif // WEBSOCKETPP_COMMON_SECURITY_CONTEXT_HPP

--- a/websocketpp/common/string_utils.hpp
+++ b/websocketpp/common/string_utils.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2014, Peter Thorson. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the WebSocket++ Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef WEBSOCKETPP_COMMON_STRING_UTILS_HPP
+#define WEBSOCKETPP_COMMON_STRING_UTILS_HPP
+
+#include <string>
+#include <locale>
+#include <cctype>
+#include <algorithm>
+
+namespace websocketpp {
+    namespace lib {
+        namespace string_utils {
+            
+                inline bool icompareCh(char lhs, char rhs) {
+                    return(::toupper(lhs) == ::toupper(rhs));
+                }
+                inline bool icompare(const std::string& s1, const std::string& s2) {
+                    return((s1.size() == s2.size()) &&
+                        std::equal(s1.begin(), s1.end(), s2.begin(), icompareCh));
+                }
+
+        }       // utils
+    }           // lib
+}               // websocket
+
+#endif // WEBSOCKETPP_COMMON_STRING_UTILS_HPP_HPP

--- a/websocketpp/config/asio.hpp
+++ b/websocketpp/config/asio.hpp
@@ -58,6 +58,8 @@ struct asio_tls : public core {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -65,6 +67,7 @@ struct asio_tls : public core {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/asio_client.hpp
+++ b/websocketpp/config/asio_client.hpp
@@ -31,6 +31,8 @@
 #include <websocketpp/config/core_client.hpp>
 #include <websocketpp/transport/asio/endpoint.hpp>
 #include <websocketpp/transport/asio/security/tls.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+#include <websocketpp/common/security_context.hpp>
 
 // Pull in non-tls config
 #include <websocketpp/config/asio_no_tls_client.hpp>
@@ -58,6 +60,8 @@ struct asio_tls_client : public core_client {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -65,6 +69,7 @@ struct asio_tls_client : public core_client {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/asio_client_authenticated_proxy.hpp
+++ b/websocketpp/config/asio_client_authenticated_proxy.hpp
@@ -1,0 +1,86 @@
+/*
+* Copyright (c) 2016, Peter Thorson. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the WebSocket++ Project nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The initial version of this Security Context policy was contributed to the WebSocket++
+* project by Colie McGarry.
+*/
+
+#ifndef WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_PROXY_AUTHENTICATED_HPP
+#define WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_PROXY_AUTHENTICATED_HPP
+
+#include <websocketpp/config/core_client.hpp>
+#include <websocketpp/transport/asio/endpoint.hpp>
+#include <websocketpp/transport/asio/security/tls.hpp>
+
+// Pull in non-tls config
+#include <websocketpp/config/asio_no_tls_client.hpp>
+
+#include <websocketpp/http/proxy_authenticator.hpp>
+#include <websocketpp/common/impl/security_context.hpp>
+
+// Define TLS config
+namespace websocketpp {
+namespace config {
+
+/// Client config with asio transport and TLS enabled
+struct asio_tls_client_authenticated_proxy : public core_client {
+    typedef asio_tls_client_authenticated_proxy type;
+    typedef core_client base;
+
+    typedef base::concurrency_type concurrency_type;
+
+    typedef base::request_type request_type;
+    typedef base::response_type response_type;
+
+    typedef base::message_type message_type;
+    typedef base::con_msg_manager_type con_msg_manager_type;
+    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
+
+    typedef base::alog_type alog_type;
+    typedef base::elog_type elog_type;
+
+    typedef base::rng_type rng_type;
+
+    typedef websocketpp::lib::security::platform::SecurityContext security_context;
+    typedef websocketpp::http::proxy::proxy_authenticator<security_context> proxy_authenticator_type;
+
+    struct transport_config : public base::transport_config {
+        typedef type::concurrency_type concurrency_type;
+        typedef type::alog_type alog_type;
+        typedef type::elog_type elog_type;
+        typedef type::request_type request_type;
+        typedef type::response_type response_type;
+        typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
+    };
+
+    typedef websocketpp::transport::asio::endpoint<transport_config>
+        transport_type;
+};
+
+} // namespace config
+} // namespace websocketpp
+
+#endif // WEBSOCKETPP_CONFIG_ASIO_TLS_CLIENT_HPP

--- a/websocketpp/config/asio_no_tls.hpp
+++ b/websocketpp/config/asio_no_tls.hpp
@@ -53,6 +53,8 @@ struct asio : public core {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -61,6 +63,7 @@ struct asio : public core {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/core.hpp
+++ b/websocketpp/config/core.hpp
@@ -61,6 +61,10 @@
 // Extensions
 #include <websocketpp/extensions/permessage_deflate/disabled.hpp>
 
+// Proxy Authentication Policy
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 namespace websocketpp {
 namespace config {
 
@@ -91,6 +95,10 @@ struct core {
 
     /// RNG policies
     typedef websocketpp::random::none::int_generator<uint32_t> rng_type;
+
+    /// Proxy Authentication Policy
+    typedef websocketpp::lib::security::SecurityContext security_context_type;
+    typedef websocketpp::http::proxy::proxy_authenticator<security_context_type> proxy_authenticator_type;
 
     /// Controls compile time enabling/disabling of thread syncronization
     /// code Disabling can provide a minor performance improvement to single

--- a/websocketpp/config/core_client.hpp
+++ b/websocketpp/config/core_client.hpp
@@ -64,6 +64,10 @@
 // Extensions
 #include <websocketpp/extensions/permessage_deflate/disabled.hpp>
 
+// Proxy Authentication Policy
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 namespace websocketpp {
 namespace config {
 
@@ -99,6 +103,10 @@ struct core_client {
     /// RNG policies
     typedef websocketpp::random::random_device::int_generator<uint32_t,
         concurrency_type> rng_type;
+
+    /// Proxy Authentication Policy
+    typedef websocketpp::lib::security::SecurityContext security_context_type;
+    typedef websocketpp::http::proxy::proxy_authenticator<security_context_type> proxy_authenticator_type;
 
     /// Controls compile time enabling/disabling of thread syncronization code
     /// Disabling can provide a minor performance improvement to single threaded

--- a/websocketpp/config/debug.hpp
+++ b/websocketpp/config/debug.hpp
@@ -61,6 +61,10 @@
 // Extensions
 #include <websocketpp/extensions/permessage_deflate/disabled.hpp>
 
+// Proxy Authentication Policy
+#include <websocketpp/common/security_context.hpp>
+#include <websocketpp/http/proxy_authenticator.hpp>
+
 namespace websocketpp {
 namespace config {
 
@@ -91,6 +95,10 @@ struct debug_core {
 
     /// RNG policies
     typedef websocketpp::random::none::int_generator<uint32_t> rng_type;
+    
+    /// Proxy Authentication Policy
+    typedef websocketpp::lib::security::SecurityContext security_context_type;
+    typedef websocketpp::http::proxy::proxy_authenticator<security_context_type> proxy_authenticator_type;
 
     /// Controls compile time enabling/disabling of thread syncronization
     /// code Disabling can provide a minor performance improvement to single

--- a/websocketpp/config/debug_asio.hpp
+++ b/websocketpp/config/debug_asio.hpp
@@ -58,6 +58,8 @@ struct debug_asio_tls : public debug_core {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -65,6 +67,7 @@ struct debug_asio_tls : public debug_core {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/debug_asio_no_tls.hpp
+++ b/websocketpp/config/debug_asio_no_tls.hpp
@@ -53,6 +53,8 @@ struct debug_asio : public debug_core {
 
     typedef base::rng_type rng_type;
 
+    typedef base::proxy_authenticator_type proxy_authenticator_type;
+
     struct transport_config : public base::transport_config {
         typedef type::concurrency_type concurrency_type;
         typedef type::alog_type alog_type;
@@ -61,6 +63,7 @@ struct debug_asio : public debug_core {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
+        typedef type::proxy_authenticator_type proxy_authenticator_type;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -384,7 +384,7 @@ public:
         , m_http_state(session::http_state::init)
         , m_was_clean(false)
     {
-        m_alog.write(log::alevel::devel, "connection copy constructor");
+        m_alog->write(log::alevel::devel, "connection copy constructor");
     }
 
     /// Get a shared pointer to this component

--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -150,6 +150,12 @@ typedef lib::function<bool(connection_hdl)> validate_handler;
  */
 typedef lib::function<void(connection_hdl)> http_handler;
 
+/// Reconnection handler
+/**
+  * 
+  */
+typedef lib::function<void(connection_hdl)> reconnect_handler;
+
 //
 typedef lib::function<void(lib::error_code const & ec, size_t bytes_transferred)> read_handler;
 typedef lib::function<void(lib::error_code const & ec)> write_frame_handler;
@@ -161,7 +167,15 @@ typedef lib::function<void(lib::error_code const & ec)> write_frame_handler;
      * @todo Move this to configs to allow compile/runtime disabling or enabling
      * of protocol versions
      */
+#ifdef _WIN32
+// Incorrect warning from VStudio compiler
+#pragma warning(push)
+#pragma warning(disable:4592)
+#endif
     static std::vector<int> const versions_supported = {0,7,8,13};
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
 #else
     /// Helper array to get around lack of initializer lists pre C++11
     static int const helper[] = {0,7,8,13};
@@ -286,10 +300,14 @@ public:
     // Misc Convenience Types
     typedef session::internal_state::value istate_type;
 
+    // Reconnect handler (Signalled if we require a reconnection)
+    typedef lib::function<void(websocketpp::connection_hdl)> reconnect_handler;
+
 private:
     enum terminate_status {
         failed = 1,
         closed,
+        proxy_reconnect,
         unknown
     };
 public:
@@ -330,6 +348,43 @@ public:
       , m_was_clean(false)
     {
         m_alog->write(log::alevel::devel,"connection constructor");
+    }
+
+    explicit connection(const connection& prev_con)
+        : transport_con_type(prev_con)
+        , m_handle_read_frame(lib::bind(
+            &type::handle_read_frame,
+            this,
+            lib::placeholders::_1,
+            lib::placeholders::_2
+            ))
+        , m_write_frame_handler(lib::bind(
+            &type::handle_write_frame,
+            this,
+            lib::placeholders::_1
+            ))
+        , m_user_agent(prev_con.m_user_agent)
+        , m_open_handshake_timeout_dur(config::timeout_open_handshake)
+        , m_close_handshake_timeout_dur(config::timeout_close_handshake)
+        , m_pong_timeout_dur(config::timeout_pong)
+        , m_max_message_size(config::max_message_size)
+        , m_state(session::state::connecting)
+        , m_internal_state(session::internal_state::USER_INIT)
+        , m_msg_manager(new con_msg_manager_type())
+        , m_send_buffer_size(0)
+        , m_write_flag(false)
+        , m_read_flag(true)
+        , m_is_server(prev_con.m_is_server)
+        , m_alog(prev_con.m_alog)
+        , m_elog(prev_con.m_elog)
+        , m_rng(prev_con.m_rng)
+        , m_local_close_code(close::status::abnormal_close)
+        , m_remote_close_code(close::status::abnormal_close)
+        , m_is_http(false)
+        , m_http_state(session::http_state::init)
+        , m_was_clean(false)
+    {
+        m_alog.write(log::alevel::devel, "connection copy constructor");
     }
 
     /// Get a shared pointer to this component
@@ -472,6 +527,10 @@ public:
      */
     void set_message_handler(message_handler h) {
         m_message_handler = h;
+    }
+
+    void set_reconnect_handler(reconnect_handler h) {
+        m_reconnect_handler = h;
     }
 
     //////////////////////////////////////////
@@ -1510,6 +1569,7 @@ private:
     http_handler            m_http_handler;
     validate_handler        m_validate_handler;
     message_handler         m_message_handler;
+    reconnect_handler       m_reconnect_handler;
 
     /// constant values
     long                    m_open_handshake_timeout_dur;

--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -69,6 +69,9 @@ public:
     /// Type of message pointers that this endpoint uses
     typedef typename connection_type::message_ptr message_ptr;
 
+    /// Type of reconnect handler (invoked if reconect required)
+    typedef typename connection_type::reconnect_handler reconnect_handler;
+
     /// Type of error logger
     typedef typename config::elog_type elog_type;
     /// Type of access logger
@@ -323,6 +326,11 @@ public:
         m_alog->write(log::alevel::devel,"set_message_handler");
         scoped_lock_type guard(m_mutex);
         m_message_handler = h;
+    }
+    void set_reconnect_handler(reconnect_handler h) {
+        m_alog.write(log::alevel::devel, "set_reconnect_handler");
+        scoped_lock_type guard(m_mutex);
+        m_reconnect_handler = h;
     }
 
     //////////////////////////////////////////
@@ -659,7 +667,7 @@ public:
         return con;
     }
 protected:
-    connection_ptr create_connection();
+    connection_ptr create_connection(connection_ptr previous_con = connection_ptr());
 
     lib::shared_ptr<alog_type> m_alog;
     lib::shared_ptr<elog_type> m_elog;
@@ -677,6 +685,7 @@ private:
     http_handler                m_http_handler;
     validate_handler            m_validate_handler;
     message_handler             m_message_handler;
+    reconnect_handler           m_reconnect_handler;
 
     long                        m_open_handshake_timeout_dur;
     long                        m_close_handshake_timeout_dur;

--- a/websocketpp/http/impl/proxy_authenticator_impl.hpp
+++ b/websocketpp/http/impl/proxy_authenticator_impl.hpp
@@ -1,0 +1,346 @@
+/*
+* Copyright (c) 2016, Peter Thorson. All rights reserved.
+*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the WebSocket++ Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The initial version of this Security Context policy was contributed to the WebSocket++
+ * project by Colie McGarry.
+ */
+
+#ifndef HTTP_PROXY_AUTHENTICATOR_IMPL_HPP
+#define HTTP_PROXY_AUTHENTICATOR_IMPL_HPP
+
+#include <websocketpp/base64/base64.hpp>
+
+#include <string>
+#include <algorithm>
+#include <locale>
+#include <cctype>
+
+namespace websocketpp {
+    namespace http {
+        namespace proxy {
+            namespace auth_parser {
+                /**
+                * Ref: https://tools.ietf.org/html/rfc7235 "2.1 Challenge and Response"
+                *
+                * challenge   = auth-scheme [ 1*SP ( token68 / #auth-param ) ]
+                *
+                * and in our case auth-scheme is one of "NTLM", "Negotiate", "Basic" or "Digest"
+                *
+                * auth-param     = token BWS "=" BWS ( token / quoted-string )
+                *
+                * BWS is basically 'optional' white space
+                *
+                * token68        = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
+                *
+                *
+                * Note: Digest is not implemented - we do parse, but we do not calculate tokens (yet)!
+                */
+
+                inline bool icompareCh(char lhs, char rhs) {
+                    return(::toupper(lhs) == ::toupper(rhs));
+                }
+                inline bool icompare(const std::string& s1, const std::string& s2) {
+                    return((s1.size() == s2.size()) &&
+                        std::equal(s1.begin(), s1.end(), s2.begin(), icompareCh));
+                }
+
+                /// Read and return the next token in the stream
+                inline bool is_token68_char(unsigned char c) {
+                    if (::isalpha(c)) return true;
+                    if (::isdigit(c)) return true;
+
+                    switch (c) {
+                    case '-': return true;
+                    case '.': return true;
+                    case '_': return true;
+                    case '~': return true;
+                    case '+': return true;
+                    case '/': return true;
+                    case '=': return true; // padding char (not strictly part of the 68!)
+                    }
+
+                    return false;
+                }
+                /// Is the character a non-token
+                inline bool is_not_token68_char(unsigned char c) {
+                    return !is_token68_char(c);
+                }
+                template <typename InputIterator>
+                inline std::pair<std::string, InputIterator> extract_token68(InputIterator begin,
+                    InputIterator end)
+                {
+                    InputIterator it = std::find_if(begin, end, &is_not_token68_char);
+                    return std::make_pair(std::string(begin, it), it);
+                }
+
+                class AuthScheme
+                {
+                public:
+                    AuthScheme(const std::string& name="") : m_name(name), m_type(Unknown)
+                    {
+                        if (icompare(m_name, "basic"))      m_type = Basic;
+                        if (icompare(m_name, "digest"))     m_type = Digest;
+                        if (icompare(m_name, "ntlm"))       m_type = NTLM;
+                        if (icompare(m_name, "negotiate"))  m_type = Negotiate;
+                    }
+
+                    std::string get_name()      const { return m_name;      }
+                    std::string get_challenge() const { return m_challenge; }
+                    std::string get_realm()     const { return m_realm;     }
+
+                    bool is_known()     const { return m_type == Unknown   ? false : true; }
+                    bool is_basic()     const { return m_type == Basic     ? true : false; }
+                    bool is_digest()    const { return m_type == Digest    ? true : false; }
+                    bool is_ntlm()      const { return m_type == NTLM      ? true : false; }
+                    bool is_negotiate() const { return m_type == Negotiate ? true : false; }
+
+                    static bool comparePriority(AuthScheme const& lhs, AuthScheme const& rhs) {
+                        return lhs.m_type > rhs.m_type;
+                    }
+
+                    template <typename InputIterator>
+                    InputIterator parse(InputIterator begin, InputIterator end) {
+                        InputIterator cursor = http::parser::extract_all_lws(begin, end);
+
+                        switch (m_type)
+                        {
+                        case Basic:     return parse_basic(cursor, end);
+                        case NTLM:      return parse_ntlm_negotiate(cursor, end);
+                        case Negotiate: return parse_ntlm_negotiate(cursor, end);
+                        
+                        case Unknown:   break;
+                        case Digest:    break;
+                        default:        break;
+                        }
+
+                        return begin;
+                    }
+
+                private:
+                    enum scheme_type { Unknown, Basic, Digest, NTLM, Negotiate };
+
+                    std::string m_name;
+                    scheme_type m_type;
+                    std::string m_challenge;
+                    std::string m_realm;
+
+                    template <typename InputIterator>
+                    InputIterator parse_basic(InputIterator begin, InputIterator end) {
+                        InputIterator cursor = begin;
+
+                        while (cursor != end) {
+                            cursor = http::parser::extract_all_lws(cursor, end);
+
+                            std::pair<std::string, InputIterator> next = http::parser::extract_token(cursor, end);
+
+                            if (next.first.empty()) {
+                                return cursor;
+                            }
+
+                            if (AuthScheme(next.first).is_known()) {
+                                return cursor;
+                            }
+
+                            std::string key = next.first;
+
+                            cursor = next.second;
+
+                            if (cursor == end || *cursor != '=') {
+                                // Expected a '=' char as part of a key value pair
+                                m_type = Unknown; 
+
+                                return cursor;
+                            }
+
+                            // Advance past the '='
+                            ++cursor;
+
+                            if (cursor == end) {
+                                // No Value
+                                m_type = Unknown;
+
+                                return cursor;
+                            }
+
+                            next = http::parser::extract_quoted_string(cursor, end);
+
+                            if (next.first.empty()) {
+                                next = http::parser::extract_token(cursor, end);
+                            }
+
+                            if (next.first.empty()) {
+                                // Expected a '=' char as part of a key value pair
+                                m_type = Unknown;
+
+                                return cursor;
+                            }
+
+                            if (icompare(key, "Realm")) {
+                                m_realm = next.first;
+                            }
+
+                            cursor = next.second;
+
+                            if (cursor != end && *cursor == ',') {
+                                ++cursor;
+                            }
+                        }
+
+                        return cursor;
+                    }
+
+                    template <typename InputIterator>
+                    InputIterator parse_ntlm_negotiate(InputIterator begin, InputIterator end) {
+                        InputIterator cursor = http::parser::extract_all_lws(begin, end);
+
+                        std::pair<std::string, InputIterator> next = extract_token68(cursor, end);
+
+                        if (!next.first.empty()) {
+                            m_challenge = next.first;
+
+                            cursor = next.second;
+                        }
+
+                        return cursor;
+                    }
+
+                };
+
+                typedef std::vector<AuthScheme> AuthSchemes;
+
+                template <typename InputIterator>
+                inline std::pair<AuthScheme, InputIterator> parse_auth_scheme(InputIterator begin, InputIterator end) {
+                    InputIterator cursor = http::parser::extract_all_lws(begin, end);
+
+                    std::pair<std::string, InputIterator> next = http::parser::extract_token(cursor, end);
+
+                    AuthScheme scheme(next.first);
+
+                    if (scheme.is_known()) {
+                        cursor = next.second;
+
+                        if (next.second != end) {
+                            cursor = scheme.parse(cursor, end);
+                        }
+                    }
+
+                    return std::make_pair(scheme, cursor);
+                }
+
+                template <typename InputIterator>
+                inline AuthSchemes parse_auth_schemes(InputIterator begin, InputIterator end) {
+                    AuthSchemes auth_schemes;
+
+                    InputIterator cursor = begin;
+
+                    while (cursor != end) {
+                        std::pair<AuthScheme,InputIterator> next = parse_auth_scheme(cursor, end);
+
+                        if (!next.first.is_known()) {
+                            return AuthSchemes();
+                        }
+
+                        auth_schemes.push_back(next.first);
+
+                        cursor = next.second;
+
+                        if (cursor != end && *cursor == ',') {
+                            ++cursor;
+                        }
+                    }
+
+                    return auth_schemes;
+                }
+
+                inline AuthScheme select_auth_scheme(std::string const & auth_headers)
+                {
+                    AuthSchemes auth_schemes = parse_auth_schemes(auth_headers.begin(), auth_headers.end());
+
+                    if (auth_schemes.empty()) {
+                        return AuthScheme();
+                    }
+
+                    std::stable_sort(auth_schemes.begin(), auth_schemes.end(), AuthScheme::comparePriority);
+
+                    return auth_schemes.front();
+                }
+
+                inline AuthScheme parse_auth_scheme(std::string const & auth_header) {
+                    std::pair<AuthScheme, std::string::const_iterator> result = parse_auth_scheme(auth_header.begin(), auth_header.end());
+
+                    return result.first;
+                }
+            }
+
+            //
+            // 'proxy_authenticator' implementation
+            //
+            template <typename security_context>
+            bool proxy_authenticator<security_context>::next_token(const std::string& auth_headers)
+            {
+                auth_parser::AuthScheme auth_scheme = auth_parser::select_auth_scheme(auth_headers);
+
+                if (!auth_scheme.is_known()) {
+                    return false;
+                }
+
+                if (auth_scheme.is_basic())
+                {
+                    m_auth_scheme_name = auth_scheme.get_name();
+
+                    // TODO: username can't contain ':' (Comment copied from old basic auth implementation)
+                    m_auth_token = base64_encode(m_basic_auth.username + ":" + m_basic_auth.password);
+
+                    return !m_basic_auth.username.empty();
+                }
+
+                if (auth_scheme.is_ntlm() || auth_scheme.is_negotiate())
+                {
+                    if (!m_security_context) {
+                        m_auth_scheme_name = auth_scheme.get_name();
+
+                        m_security_context = security_context::build(m_proxy, m_auth_scheme_name);
+                    }
+
+                    if (!m_security_context) {
+                        return false;
+                    }
+
+                    m_security_context->nextAuthToken(auth_scheme.get_challenge());
+
+                    m_auth_token = m_security_context->getUpdatedToken();
+
+                    return m_auth_token.empty() ? false : true;
+                }
+
+                return false;
+            }
+        }   // namespace proxy
+    }       // namespace http
+}           // namespace websocketpp
+
+//#include <websocketpp/http/impl/proxy_authenticator.hpp>
+
+#endif // HTTP_PROXY_AUTHENTICATOR_IMPL_HPP

--- a/websocketpp/http/impl/proxy_authenticator_impl.hpp
+++ b/websocketpp/http/impl/proxy_authenticator_impl.hpp
@@ -31,6 +31,7 @@
 #define HTTP_PROXY_AUTHENTICATOR_IMPL_HPP
 
 #include <websocketpp/base64/base64.hpp>
+#include <websocketpp/common/string_utils.hpp>
 
 #include <string>
 #include <algorithm>
@@ -57,14 +58,6 @@ namespace websocketpp {
                 *
                 * Note: Digest is not implemented - we do parse, but we do not calculate tokens (yet)!
                 */
-
-                inline bool icompareCh(char lhs, char rhs) {
-                    return(::toupper(lhs) == ::toupper(rhs));
-                }
-                inline bool icompare(const std::string& s1, const std::string& s2) {
-                    return((s1.size() == s2.size()) &&
-                        std::equal(s1.begin(), s1.end(), s2.begin(), icompareCh));
-                }
 
                 /// Read and return the next token in the stream
                 inline bool is_token68_char(unsigned char c) {
@@ -100,6 +93,8 @@ namespace websocketpp {
                 public:
                     AuthScheme(const std::string& name="") : m_name(name), m_type(Unknown)
                     {
+                        using namespace websocketpp::lib::string_utils;
+                        
                         if (icompare(m_name, "basic"))      m_type = Basic;
                         if (icompare(m_name, "digest"))     m_type = Digest;
                         if (icompare(m_name, "ntlm"))       m_type = NTLM;
@@ -197,7 +192,7 @@ namespace websocketpp {
                                 return cursor;
                             }
 
-                            if (icompare(key, "Realm")) {
+                            if (websocketpp::lib::string_utils::icompare(key, "Realm")) {
                                 m_realm = next.first;
                             }
 

--- a/websocketpp/http/impl/response.hpp
+++ b/websocketpp/http/impl/response.hpp
@@ -137,20 +137,19 @@ inline size_t response::consume(char const * buf, size_t len) {
 }
 
 inline size_t response::consume(std::istream & s) {
-    char buf[istream_buffer];
-    size_t bytes_read;
-    size_t bytes_processed;
     size_t total = 0;
 
     while (s.good()) {
-        s.getline(buf,istream_buffer);
-        bytes_read = static_cast<size_t>(s.gcount());
+        std::string line;
+        size_t bytes_processed=0;
+
+        std::getline(s, line);
 
         if (s.fail() || s.eof()) {
-            bytes_processed = this->consume(buf,bytes_read);
+            bytes_processed = this->consume(line.c_str(),line.length());
             total += bytes_processed;
 
-            if (bytes_processed != bytes_read) {
+            if (bytes_processed != line.length()) {
                 // problem
                 break;
             }
@@ -161,11 +160,11 @@ inline size_t response::consume(std::istream & s) {
             // the delimiting newline was found. Replace the trailing null with
             // the newline that was discarded, since our raw consume function
             // expects the newline to be be there.
-            buf[bytes_read-1] = '\n';
-            bytes_processed = this->consume(buf,bytes_read);
+            line += '\n';
+            bytes_processed = this->consume(line.c_str(),line.length());
             total += bytes_processed;
 
-            if (bytes_processed != bytes_read) {
+            if (bytes_processed != line.length()) {
                 // problem
                 break;
             }

--- a/websocketpp/http/proxy_authenticator.hpp
+++ b/websocketpp/http/proxy_authenticator.hpp
@@ -1,0 +1,171 @@
+/*
+* Copyright (c) 2016, Peter Thorson. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of the WebSocket++ Project nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL PETER THORSON BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The initial version of this Security Context policy was contributed to the WebSocket++
+* project by Colie McGarry.
+*/
+
+#ifndef HTTP_PROXY_AUTHENTICATOR_HPP
+#define HTTP_PROXY_AUTHENTICATOR_HPP
+
+#include <websocketpp/common/memory.hpp>
+
+#include <websocketpp/http/response.hpp>
+
+#include <string>
+#include <algorithm>
+#include <locale>
+#include <cctype>
+
+namespace websocketpp {
+    namespace http {
+        namespace proxy {
+
+            /// The 'proxy_authenticator' manages parsing and tokens required for proxy autentication.
+            /**
+            * The proxy authenticator handles http proxy authentication. It supports 'Basic', 'NTLM'
+            * and 'Negotiate' authentation - depending on the security context object used. Currently 
+            * there is a Win32 security context which will authenticate using the signed on users
+            * credentials for NTLM and Negotiate. 
+            *
+            * Where the proxy supports multiple different auth schemes, the proxy authenticator will 
+            * select the scheme using the following priority:
+            *   1. Negotiate
+            *   2. NTLM
+            *   3. Digest (not supported just now)
+            *   4. Basic
+            *  
+            */
+            template <typename security_context>
+            class proxy_authenticator {
+            private:
+                typedef typename security_context::Ptr security_context_ptr;
+
+                std::string m_proxy;
+                std::string m_auth_scheme_name;
+                std::string m_auth_token;
+                bool authenticated;
+
+                struct
+                {
+                    std::string username;
+                    std::string password;
+
+                } m_basic_auth;
+
+                security_context_ptr m_security_context;
+
+                std::string build_auth_response() {
+                    if (!m_auth_scheme_name.empty() && !m_auth_token.empty()) {
+                        return m_auth_scheme_name + " " + m_auth_token;
+                    }
+
+                    return "";
+                }
+
+            public:
+                typedef lib::shared_ptr<proxy_authenticator> ptr;
+
+                /// Construct a 'proxy_authenticator'
+                /**
+                * Constructs a proxy authenticator fo a given proxy
+                *
+                * @param proxy: Complete proxy URI eg http://proxy.example.com:8080/
+                */
+                proxy_authenticator(std::string const& proxy) : m_proxy(proxy), authenticated(false) {
+                }
+
+                /// Set Basice authentication credentials
+                /**
+                * This method sets the basic auth credentials. This can be used for Basic 
+                * authentication, and Digest, however only Basic is supported just now.
+                *
+                * @param username: username used in the auth response.
+                * @param password: password used in the aut response
+                */
+                void set_basic_auth(std::string const& username, std::string const& password)
+                {
+                    m_basic_auth.username = username;
+                    m_basic_auth.password = password;
+                }
+
+                /// Calculate the next auth token
+                /**
+                * Using the reponse from the proxy, be that the initial response with a list
+                * of auth schemes, or a subsequent response with a scheme and a challenge token,
+                * this method will calculate the next auth token to be used. 
+                *
+                * @param auth_headers: Response headers from 'Proxy-Authenticate'
+                *
+                * Return: ture:  New token calculated, continue auth flow.
+                *         false: No new token calculated - fail the auth flow
+                */
+                bool next_token(std::string const& auth_headers);
+
+                /// Return the next calculated auth token
+                /**
+                * This method will return the next calculated auth token for use in the 
+                * 'Proxy-Authorization' header field.
+                *
+                * Return: New Auth token for 'Proxy-Authorization' header.
+                */
+                std::string get_auth_token() {
+                    return build_auth_response();
+                }
+
+                /// To be called after 'proxy_authentication' is complete
+                /**
+                * Marks this authenticator as complete, which means 'get_authenticated_token()
+                * returns the valid token for proxy authentication. 
+                */
+                void set_authenticated() {
+                    authenticated = true;
+                }
+
+                /// Returns the authenticated token after auth complete
+                /**
+                * 
+                */
+                std::string get_authenticated_token() {
+                    return authenticated ? build_auth_response() : "";
+                }
+
+                /// Returns the proxy uri
+                /**
+                * 
+                */
+                std::string get_proxy() {
+                    return m_proxy;
+                }
+
+            };
+
+        }   // namespace proxy
+    }       // namespace http
+}           // namespace websocketpp
+
+#include <websocketpp/http/impl/proxy_authenticator_impl.hpp>
+
+#endif // HTTP_PROXY_AUTHENTICATOR_HPP

--- a/websocketpp/http/response.hpp
+++ b/websocketpp/http/response.hpp
@@ -157,6 +157,11 @@ public:
     const std::string& get_status_msg() const {
         return m_status_msg;
     }
+
+    size_t get_content_length() const {
+        return m_read;
+    }
+
 private:
     /// Helper function for consume. Process response line
     void process(std::string::iterator begin, std::string::iterator end);

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -750,7 +750,7 @@ void connection<config>::handle_transport_init(lib::error_code const & ec) {
 
     if (ecm == transport::error::proxy_reconnect)
     {
-        m_elog.write(log::elevel::rerror, "handle_transport_init proxy reconned required");
+        m_elog->write(log::elevel::rerror, "handle_transport_init proxy reconned required");
 
         if(m_reconnect_handler) {
             m_reconnect_handler(m_connection_hdl);

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -748,6 +748,19 @@ void connection<config>::handle_transport_init(lib::error_code const & ec) {
         ecm = error::make_error_code(error::invalid_state);
     }
 
+    if (ecm == transport::error::proxy_reconnect)
+    {
+        m_elog.write(log::elevel::rerror, "handle_transport_init proxy reconned required");
+
+        if(m_reconnect_handler) {
+            m_reconnect_handler(m_connection_hdl);
+
+            return;
+        }
+
+        return;
+    }
+
     if (ecm) {
         std::stringstream s;
         s << "handle_transport_init received error: "<< ecm.message();

--- a/websocketpp/impl/endpoint_impl.hpp
+++ b/websocketpp/impl/endpoint_impl.hpp
@@ -34,8 +34,8 @@ namespace websocketpp {
 
 template <typename connection, typename config>
 typename endpoint<connection,config>::connection_ptr
-endpoint<connection,config>::create_connection() {
-    m_alog->write(log::alevel::devel,"create_connection");
+endpoint<connection,config>::create_connection(connection_ptr previous_con) {
+    m_alog.write(log::alevel::devel,"create_connection");
     //scoped_lock_type lock(m_state_lock);
 
     /*if (m_state == STOPPING || m_state == STOPPED) {
@@ -44,8 +44,14 @@ endpoint<connection,config>::create_connection() {
 
     //scoped_lock_type guard(m_mutex);
     // Create a connection on the heap and manage it using a shared pointer
-    connection_ptr con = lib::make_shared<connection_type>(m_is_server,
-        m_user_agent, m_alog, m_elog, lib::ref(m_rng));
+    connection_ptr con;
+
+    if (previous_con) {
+        con = lib::make_shared<connection_type>(*previous_con);
+    }
+    else {
+        con = lib::make_shared<connection_type>(m_is_server, m_user_agent, lib::ref(m_alog), lib::ref(m_elog), lib::ref(m_rng));
+    }
 
     connection_weak_ptr w(con);
 
@@ -66,7 +72,8 @@ endpoint<connection,config>::create_connection() {
     con->set_http_handler(m_http_handler);
     con->set_validate_handler(m_validate_handler);
     con->set_message_handler(m_message_handler);
-
+    con->set_reconnect_handler(m_reconnect_handler);
+    
     if (m_open_handshake_timeout_dur != config::timeout_open_handshake) {
         con->set_open_handshake_timeout(m_open_handshake_timeout_dur);
     }

--- a/websocketpp/impl/endpoint_impl.hpp
+++ b/websocketpp/impl/endpoint_impl.hpp
@@ -35,7 +35,7 @@ namespace websocketpp {
 template <typename connection, typename config>
 typename endpoint<connection,config>::connection_ptr
 endpoint<connection,config>::create_connection(connection_ptr previous_con) {
-    m_alog.write(log::alevel::devel,"create_connection");
+    m_alog->write(log::alevel::devel,"create_connection");
     //scoped_lock_type lock(m_state_lock);
 
     /*if (m_state == STOPPING || m_state == STOPPED) {

--- a/websocketpp/roles/client_endpoint.hpp
+++ b/websocketpp/roles/client_endpoint.hpp
@@ -105,6 +105,22 @@ public:
         return con;
     }
 
+    connection_ptr get_reconnection(connection_ptr prev_con, lib::error_code & ec) {
+
+        connection_ptr con = endpoint_type::create_connection(prev_con);
+
+        if (!con) {
+            ec = error::make_error_code(error::con_creation_failed);
+            return con;
+        }
+
+        con->set_uri(prev_con->get_uri()); 
+
+        ec = lib::error_code();
+        return con;
+    }
+
+
     /// Get a new connection (string version)
     /**
      * Creates and returns a pointer to a new connection to the given URI

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -119,7 +119,7 @@ public:
         , m_proxy(con.m_proxy)
         , m_proxy_data(con.m_proxy_data)
     {
-        m_alog.write(log::alevel::devel, "asio con transport constructor");
+        m_alog->write(log::alevel::devel, "asio con transport constructor");
     }
 
     /// Get a shared pointer to this component
@@ -826,7 +826,7 @@ protected:
             }
 
             if (m_proxy_data->res.get_status_code() == http::status_code::proxy_authentication_required) {
-                m_elog.write(log::elevel::info, "Proxy authorization Required");
+                m_elog->write(log::elevel::info, "Proxy authorization Required");
 
                 std::string auth_headers = m_proxy_data->res.get_header("Proxy-Authenticate");
 

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -45,6 +45,7 @@
 #include <websocketpp/common/memory.hpp>
 #include <websocketpp/common/functional.hpp>
 #include <websocketpp/common/connection_hdl.hpp>
+#include <websocketpp/common/string_utils.hpp>
 
 #include <istream>
 #include <sstream>
@@ -820,7 +821,7 @@ protected:
 
             std::string connection_header = m_proxy_data->res.get_header("Connection");
 
-            if (connection_header == "Close") {
+            if (websocketpp::lib::string_utils::icompare(connection_header, "Close")) {
                 reconnect = true;
             }
 

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -765,7 +765,7 @@ protected:
         }
     }
 
-    size_t proxy_read_body_completion(size_t to_read, lib::asio::error_code const & ec, size_t transferred)
+    size_t proxy_read_body_completion(size_t to_read, lib::asio::error_code const & /*ec*/, size_t transferred)
     {
         size_t result = 512; // istream_buffer;
 

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -92,6 +92,10 @@ public:
     /// Type of a pointer to the Asio timer class
     typedef lib::shared_ptr<lib::asio::steady_timer> timer_ptr;
 
+    /// Type of proxy authentication policy
+    typedef typename config::proxy_authenticator_type proxy_authenticator_type;
+    typedef typename proxy_authenticator_type::ptr proxy_authenticator_ptr;
+
     // connection is friends with its associated endpoint to allow the endpoint
     // to call private/protected utility methods that we don't want to expose
     // to the public api.
@@ -104,6 +108,17 @@ public:
       , m_elog(elog)
     {
         m_alog->write(log::alevel::devel,"asio con transport constructor");
+    }
+
+    // build a new connection object from an existing one
+    explicit connection(const connection& con)
+        : m_is_server(con.m_is_server)
+        , m_alog(con.m_alog)
+        , m_elog(con.m_elog)
+        , m_proxy(con.m_proxy)
+        , m_proxy_data(con.m_proxy_data)
+    {
+        m_alog.write(log::alevel::devel, "asio con transport constructor");
     }
 
     /// Get a shared pointer to this component
@@ -129,6 +144,9 @@ public:
      */
     void set_uri(uri_ptr u) {
         socket_con_type::set_uri(u);
+    }
+    uri_ptr get_uri() {
+        return socket_con_type::get_uri();
     }
 
     /// Sets the tcp pre init handler
@@ -192,6 +210,8 @@ public:
         m_proxy = uri;
         m_proxy_data = lib::make_shared<proxy_data>();
         ec = lib::error_code();
+
+        m_proxy_data->proxy_authenticator = lib::make_shared<proxy_authenticator_type>(m_proxy);
     }
 
     /// Set the proxy to connect through (exception)
@@ -222,9 +242,10 @@ public:
             return;
         }
 
-        // TODO: username can't contain ':'
-        std::string val = "Basic "+base64_encode(username + ":" + password);
-        m_proxy_data->req.replace_header("Proxy-Authorization",val);
+        if (m_proxy_data->proxy_authenticator) {
+            m_proxy_data->proxy_authenticator->set_basic_auth(username, password);
+        }
+
         ec = lib::error_code();
     }
 
@@ -442,7 +463,17 @@ protected:
         m_proxy_data->req.set_method("CONNECT");
 
         m_proxy_data->req.set_uri(authority);
-        m_proxy_data->req.replace_header("Host",authority);
+        m_proxy_data->req.replace_header("Host", authority);
+        //m_proxy)data->req.replace_header("Connection", "Keep-alive");
+
+        if (m_proxy_data->proxy_authenticator) {
+
+            std::string auth_token = m_proxy_data->proxy_authenticator->get_auth_token();
+
+            if (!auth_token.empty()) {
+                m_proxy_data->req.replace_header("Proxy-Authorization", auth_token);
+            }
+        }
 
         return lib::error_code();
     }
@@ -784,6 +815,47 @@ protected:
             }
 
             m_alog->write(log::alevel::devel,m_proxy_data->res.raw());
+
+            bool reconnect = false;
+
+            std::string connection_header = m_proxy_data->res.get_header("Connection");
+
+            if (connection_header == "Close") {
+                reconnect = true;
+            }
+
+            if (m_proxy_data->res.get_status_code() == http::status_code::proxy_authentication_required) {
+                m_elog.write(log::elevel::info, "Proxy authorization Required");
+
+                std::string auth_headers = m_proxy_data->res.get_header("Proxy-Authenticate");
+
+                if (m_proxy_data->proxy_authenticator) {
+
+                    bool next_token = m_proxy_data->proxy_authenticator->next_token(auth_headers);
+
+                    if (next_token && !reconnect) {
+                        m_proxy_data->res = response_type();
+                        m_proxy_data->req.replace_header("Proxy-Authorization", m_proxy_data->proxy_authenticator->get_auth_token());
+
+                        proxy_write(callback);
+
+                        return;
+                    }
+                }
+            }
+
+            if (m_proxy_data->proxy_authenticator) {
+                if (m_proxy_data->res.get_status_code() == http::status_code::ok) {
+                    m_proxy_data->proxy_authenticator->set_authenticated();
+                }
+
+                if (reconnect) {
+                    m_proxy_data->res = response_type();
+                    callback(make_error_code(transport::error::proxy_reconnect));
+
+                    return;
+                }
+            }
 
             if (m_proxy_data->res.get_status_code() != http::status_code::ok) {
                 // got an error response back
@@ -1173,6 +1245,7 @@ private:
         lib::asio::streambuf read_buf;
         long timeout_proxy;
         timer_ptr timer;
+        proxy_authenticator_ptr proxy_authenticator;
     };
 
     std::string m_proxy;

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -869,11 +869,11 @@ protected:
 
             std::string connection_header = m_proxy_data->res.get_header("Connection");
 
-            if (websocketpp::lib::string_utils::icompare(connection_header, "Close")) {
-                reconnect = true;
-            }
-
             if (m_proxy_data->res.get_status_code() == http::status_code::proxy_authentication_required) {
+                if (websocketpp::lib::string_utils::icompare(connection_header, "Close")) {
+                    reconnect = true;
+                }
+
                 m_elog->write(log::elevel::info, "Proxy authorization Required");
 
                 std::string auth_headers = m_proxy_data->res.get_header("Proxy-Authenticate");

--- a/websocketpp/transport/base/connection.hpp
+++ b/websocketpp/transport/base/connection.hpp
@@ -177,7 +177,10 @@ enum value {
     action_after_shutdown,
 
     /// Other TLS error
-    tls_error
+    tls_error,
+
+    /// Proxy Reconnection required
+    proxy_reconnect,
 };
 
 class category : public lib::error_category {

--- a/websocketpp/transport/iostream/connection.hpp
+++ b/websocketpp/transport/iostream/connection.hpp
@@ -88,7 +88,20 @@ public:
     {
         m_alog->write(log::alevel::devel,"iostream con transport constructor");
     }
-
+    
+    // Note: Only including this copy constructor to address a build break
+    // build a new connection object from an existing one
+    explicit connection(const connection& con)
+      : m_output_stream(NULL)
+      , m_reading(con.m_reading)
+      , m_is_server(con.m_is_server)
+      , m_is_secure(con.m_is_secure)
+      , m_alog(con.m_alog)
+      , m_elog(con.m_elog)
+      , m_remote_endpoint("iostream transport")
+    {
+    }
+    
     /// Get a shared pointer to this component
     ptr get_shared() {
         return type::shared_from_this();


### PR DESCRIPTION
This is a follow on pull request from proxy_auth3 (https://github.com/zaphoyd/websocketpp/pull/535)

Customers have been using the updated WebSocket library with authenticated proxy support, and we've been working so far. 

So another customer with a slightly different proxy has hit an issue around "Connection:Close" header handling, and I've update WebSocket to handle this case. 

Please consider this for inclusion in WebSocket, because when this is included, we can then updated cpprestsdk, to include the master of WebSocket - or the next release, and we can return to the master of cpprestsdk. 

Thank you 