### PR TITLE
cmake: install correct .cmake files

### DIFF
--- a/websocketpp-config.cmake.in
+++ b/websocketpp-config.cmake.in
@@ -4,4 +4,4 @@
 #  WEBSOCKETPP_INCLUDE_DIR - include directories
 
 set(WEBSOCKETPP_FOUND TRUE)
-set(WEBSOCKETPP_INCLUDE_DIR "@INSTALL_INCLUDE_DIR@")
+find_path(WEBSOCKETPP_INCLUDE_DIR "websocketpp/version.hpp")


### PR DESCRIPTION
Currently, we install a .cmake file (so that other packages can find us)
that sets the include path to /usr/include.

This does not work in cross-compilation, as it points to the build
machine headers, so is not correct for cross-compilation, for two
reasons:
  - websocketpp might not be installed on the build machine,
  - it might be installed as a different version.

Thus, we need to let cmake find the correct include path.

We do so by searching the include directory that contains a specific
file of our own; we choose websocketpp/version.h as the file to look
for.

This then properly sets the include path, which is even often uneeded
as it will be the standard search path (either /usr/include for native
builds, or .../sysroot/usr/include for cross builds).

Thanks to Samuel for hinting me at find_path(). :-)

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
Cc: Samuel Martin <s.martin49@gmail.com>