### PR TITLE
Made endpoint::get_con_from_hdl()s static, don't need an endpoint reference to upgrade handle to connection.

### DIFF
--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -640,7 +640,7 @@ public:
      *
      * @return the connection_ptr. May be NULL if the handle was invalid.
      */
-    connection_ptr get_con_from_hdl(connection_hdl hdl, lib::error_code & ec) {
+    static connection_ptr get_con_from_hdl(connection_hdl hdl, lib::error_code & ec) {
         connection_ptr con = lib::static_pointer_cast<connection_type>(
             hdl.lock());
         if (!con) {
@@ -650,9 +650,9 @@ public:
     }
 
     /// Retrieves a connection_ptr from a connection_hdl (exception version)
-    connection_ptr get_con_from_hdl(connection_hdl hdl) {
+    static connection_ptr get_con_from_hdl(connection_hdl hdl) {
         lib::error_code ec;
-        connection_ptr con = this->get_con_from_hdl(hdl,ec);
+        connection_ptr con = get_con_from_hdl(hdl,ec);
         if (ec) {
             throw exception(ec);
         }


### PR DESCRIPTION
Hi

I've been working on integrating WebSocket support in to an existing socket library (using the iostream transport as a guide, very handy!) and found that endpoint::get_con_from_hdl() could be static. Makes my code a lot less couple-y, given the way it is structured.

Anyway, if it's of interest, here's the change. Obviously very trivial!

Thanks

Luke.