### PR TITLE
Implemented close code 1014

### DIFF
--- a/test/utility/close.cpp
+++ b/test/utility/close.cpp
@@ -39,7 +39,6 @@ using namespace websocketpp;
 BOOST_AUTO_TEST_CASE( reserved_values ) {
     BOOST_CHECK( !close::status::reserved(999) );
     BOOST_CHECK( close::status::reserved(1004) );
-    BOOST_CHECK( close::status::reserved(1014) );
     BOOST_CHECK( close::status::reserved(1016) );
     BOOST_CHECK( close::status::reserved(2999) );
     BOOST_CHECK( !close::status::reserved(1000) );

--- a/websocketpp/close.hpp
+++ b/websocketpp/close.hpp
@@ -142,6 +142,11 @@ namespace status {
     /// or reconnect to the same IP upon user action.
     static value const try_again_later = 1013;
 
+    /// Indicates that the server was acting as a gateway or proxy and received
+    /// an invalid response from the upstream server. This is similar to 502
+    /// HTTP Status Code.
+    static value const bad_gateway = 1014;
+
     /// An endpoint failed to perform a TLS handshake
     /**
      * Designated for use in applications expecting a status code to indicate
@@ -178,7 +183,7 @@ namespace status {
      */
     inline bool reserved(value code) {
         return ((code >= rsv_start && code <= rsv_end) ||
-                code == 1004 || code == 1014);
+                code == 1004);
     }
 
     /// First value in range that is always invalid on the wire
@@ -248,6 +253,12 @@ namespace status {
                 return "Extension required";
             case internal_endpoint_error:
                 return "Internal endpoint error";
+            case service_restart:
+                return "Service restart";
+            case try_again_later:
+                return "Try again laster";
+            case bad_gateway:
+                return "Bad gateway";
             case tls_handshake:
                 return "TLS handshake failure";
             case subprotocol_error:


### PR DESCRIPTION
Also adds two missing messages to get_string()

Reference: https://www.ietf.org/mail-archive/web/hybi/current/msg10748.html
Confirmation: https://www.ietf.org/mail-archive/web/hybi/current/msg10753.html
