### PR TITLE
C++17 compliance

### DIFF
--- a/websocketpp/common/memory.hpp
+++ b/websocketpp/common/memory.hpp
@@ -65,7 +65,6 @@ namespace lib {
 #ifdef _WEBSOCKETPP_CPP11_MEMORY_
     using std::shared_ptr;
     using std::weak_ptr;
-    using std::auto_ptr;
     using std::enable_shared_from_this;
     using std::static_pointer_cast;
     using std::make_shared;
@@ -75,7 +74,6 @@ namespace lib {
 #else
     using boost::shared_ptr;
     using boost::weak_ptr;
-    using std::auto_ptr;
     using boost::enable_shared_from_this;
     using boost::static_pointer_cast;
     using boost::make_shared;

--- a/websocketpp/utilities.hpp
+++ b/websocketpp/utilities.hpp
@@ -72,10 +72,9 @@ private:
  * Based on code from
  * http://stackoverflow.com/questions/3152241/case-insensitive-stdstring-find
  */
-struct ci_less : std::binary_function<std::string, std::string, bool> {
+struct ci_less {
     // case-independent (ci) compare_less binary function
     struct nocase_compare
-      : public std::binary_function<unsigned char,unsigned char,bool>
     {
         bool operator() (unsigned char const & c1, unsigned char const & c2) const {
             return tolower (c1) < tolower (c2);


### PR DESCRIPTION
The new c++ 17 standard removes std::auto_ptr and std::binary_function. 
websocketpp contains them in memory.hpp and utilities.hpp respectively.
websocketpp cannot be compiled with those anymore on the latest VS"15".
