### PR TITLE
Expose HTTP request headers

### DIFF
--- a/websocketpp/http/impl/parser.hpp
+++ b/websocketpp/http/impl/parser.hpp
@@ -176,6 +176,10 @@ inline void parser::process_header(std::string::iterator begin,
                   strip_lws(std::string(cursor+sizeof(header_separator)-1,end)));
 }
 
+inline header_list headers() const {
+    return m_headers;
+}
+
 inline std::string parser::raw_headers() const {
     std::stringstream raw;
 

--- a/websocketpp/http/parser.hpp
+++ b/websocketpp/http/parser.hpp
@@ -590,6 +590,12 @@ protected:
         return (m_body_bytes_needed == 0);
     }
 
+    /// Return a list of all HTTP headers
+    /**
+     * Return a list of all HTTP headers
+     */
+    header_list headers() const;
+
     /// Generate and return the HTTP headers as a string
     /**
      * Each headers will be followed by the \r\n sequence including the last one.


### PR DESCRIPTION
This change allows users to get a full list of HTTP request headers
allowing libraries that build on top of websocketpp to pass those on
to their users without exposing access to the already existing getter
methods.