### PR TITLE
stdint header included to fix uintXX_t compilation error

### DIFF
--- a/websocketpp/extensions/permessage_deflate/disabled.hpp
+++ b/websocketpp/extensions/permessage_deflate/disabled.hpp
@@ -29,6 +29,7 @@
 #define WEBSOCKETPP_EXTENSION_PERMESSAGE_DEFLATE_DISABLED_HPP
 
 #include <websocketpp/common/cpp11.hpp>
+#include <websocketpp/common/stdint.hpp>
 #include <websocketpp/common/system_error.hpp>
 
 #include <websocketpp/http/constants.hpp>

--- a/websocketpp/extensions/permessage_deflate/enabled.hpp
+++ b/websocketpp/extensions/permessage_deflate/enabled.hpp
@@ -32,6 +32,7 @@
 #include <websocketpp/common/cpp11.hpp>
 #include <websocketpp/common/memory.hpp>
 #include <websocketpp/common/platforms.hpp>
+#include <websocketpp/common/stdint.hpp>
 #include <websocketpp/common/system_error.hpp>
 #include <websocketpp/error.hpp>
 

--- a/websocketpp/uri.hpp
+++ b/websocketpp/uri.hpp
@@ -31,6 +31,7 @@
 #include <websocketpp/error.hpp>
 
 #include <websocketpp/common/memory.hpp>
+#include <websocketpp/common/stdint.hpp>
 
 #include <algorithm>
 #include <sstream>


### PR DESCRIPTION
Fixes g++ 5.4.0 error: ‘uint8_t’ was not declared in this scope