### PR TITLE
Fix refused client connection due to servers not yet started

### DIFF
--- a/test/transport/integration.cpp
+++ b/test/transport/integration.cpp
@@ -375,6 +375,8 @@ BOOST_AUTO_TEST_CASE( pong_no_timeout ) {
 
     websocketpp::lib::thread sthread(websocketpp::lib::bind(&run_server,&s,9005,false));
 
+    sleep(1); // give the server thread some time to start
+
     // Run a client that closes the connection after 1 seconds
     run_time_limited_client(c, "http://localhost:9005", 1, false);
 
@@ -401,6 +403,8 @@ BOOST_AUTO_TEST_CASE( pong_timeout ) {
     websocketpp::lib::thread tthread(websocketpp::lib::bind(&run_test_timer,10));
     tthread.detach();
 
+    sleep(1); // give the server thread some time to start
+
     run_client(c, "http://localhost:9005",false);
 
     sthread.join();
@@ -420,6 +424,8 @@ BOOST_AUTO_TEST_CASE( client_open_handshake_timeout ) {
     sthread.detach();
     tthread.detach();
 
+    sleep(1); // give the server thread some time to start
+
     run_client(c, "http://localhost:9005");
 }
 
@@ -435,6 +441,8 @@ BOOST_AUTO_TEST_CASE( server_open_handshake_timeout ) {
     websocketpp::lib::thread sthread(websocketpp::lib::bind(&run_server,&s,9005,false));
     websocketpp::lib::thread tthread(websocketpp::lib::bind(&run_test_timer,10));
     tthread.detach();
+
+    sleep(1); // give the server thread some time to start
 
     run_dummy_client("9005");
 
@@ -458,6 +466,8 @@ BOOST_AUTO_TEST_CASE( client_self_initiated_close_handshake_timeout ) {
     websocketpp::lib::thread sthread(websocketpp::lib::bind(&run_server,&s,9005,false));
     websocketpp::lib::thread tthread(websocketpp::lib::bind(&run_test_timer,10));
     tthread.detach();
+
+    sleep(1); // give the server thread some time to start
 
     run_client(c, "http://localhost:9005", false);
 
@@ -491,7 +501,9 @@ BOOST_AUTO_TEST_CASE( server_self_initiated_close_handshake_timeout ) {
     websocketpp::lib::thread tthread(websocketpp::lib::bind(&run_test_timer,10));
     tthread.detach();
 
-    run_client(c, "http://localhost:9005",false);
+    sleep(1); // give the server thread some time to start
+
+    run_client(c, "http://localhost:9005", false);
 
     sthread.join();
 }
@@ -569,7 +581,9 @@ BOOST_AUTO_TEST_CASE( stop_listening ) {
     websocketpp::lib::thread tthread(websocketpp::lib::bind(&run_test_timer,5));
     tthread.detach();
 
-    run_client(c, "http://localhost:9005",false);
+    sleep(1); // give the server thread some time to start
+
+    run_client(c, "http://localhost:9005", false);
 
     sthread.join();
 }


### PR DESCRIPTION
The server thread in a unit test may not have enough time to start and the
ongoing client connection will be refused. Fix this by adding sleep.