### PR TITLE
Preserve ASIO errors if possible

### DIFF
--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -423,7 +423,7 @@ public:
                 m_acceptor->close();
             }
             log_err(log::elevel::info,"asio listen",bec);
-            ec = make_error_code(error::pass_through);
+            ec = socket_con_type::translate_ec(ec);
         } else {
             m_state = LISTENING;
             ec = lib::error_code();
@@ -733,7 +733,7 @@ public:
                 m_elog->write(log::elevel::info,
                     "asio handle_timer error: "+ec.message());
                 log_err(log::elevel::info,"asio handle_timer",ec);
-                callback(make_error_code(error::pass_through));
+                callback(socket_con_type::translate_ec(ec));
             }
         } else {
             callback(lib::error_code());
@@ -818,7 +818,7 @@ protected:
                 ret_ec = make_error_code(websocketpp::error::operation_canceled);
             } else {
                 log_err(log::elevel::info,"asio handle_accept",asio_ec);
-                ret_ec = make_error_code(error::pass_through);
+                ret_ec = socket_con_type::translate_ec(asio_ec);
             }
         }
 
@@ -961,7 +961,7 @@ protected:
 
         if (ec) {
             log_err(log::elevel::info,"asio async_resolve",ec);
-            callback(make_error_code(error::pass_through));
+            callback(socket_con_type::translate_ec(ec));
             return;
         }
 
@@ -1069,7 +1069,7 @@ protected:
 
         if (ec) {
             log_err(log::elevel::info,"asio async_connect",ec);
-            callback(make_error_code(error::pass_through));
+            callback(socket_con_type::translate_ec(ec));
             return;
         }
 

--- a/websocketpp/transport/asio/security/none.hpp
+++ b/websocketpp/transport/asio/security/none.hpp
@@ -261,6 +261,7 @@ protected:
         return lib::error_code();
     }
 
+public:
     /// Translate any security policy specific information about an error code
     /**
      * Translate_ec takes an Asio error code and attempts to convert its value 

--- a/websocketpp/transport/asio/security/none.hpp
+++ b/websocketpp/transport/asio/security/none.hpp
@@ -280,11 +280,13 @@ protected:
      * @return The translated error code
      */
     template <typename ErrorCodeType>
+    static
     lib::error_code translate_ec(ErrorCodeType) {
         // We don't know any more information about this error so pass through
         return make_error_code(transport::error::pass_through);
     }
-    
+
+    static
     /// Overload of translate_ec to catch cases where lib::error_code is the 
     /// same type as lib::asio::error_code
     lib::error_code translate_ec(lib::error_code ec) {

--- a/websocketpp/transport/asio/security/tls.hpp
+++ b/websocketpp/transport/asio/security/tls.hpp
@@ -333,6 +333,7 @@ protected:
         }
     }
 
+public:
     /// Translate any security policy specific information about an error code
     /**
      * Translate_ec takes an Asio error code and attempts to convert its value

--- a/websocketpp/transport/asio/security/tls.hpp
+++ b/websocketpp/transport/asio/security/tls.hpp
@@ -353,6 +353,7 @@ protected:
      * @return The translated error code
      */
     template <typename ErrorCodeType>
+    static
     lib::error_code translate_ec(ErrorCodeType ec) {
         if (ec.category() == lib::asio::error::get_ssl_category()) {
             if (ERR_GET_REASON(ec.value()) == SSL_R_SHORT_READ) {
@@ -368,7 +369,8 @@ protected:
             return make_error_code(transport::error::pass_through);
         }
     }
-    
+
+    static
     /// Overload of translate_ec to catch cases where lib::error_code is the
     /// same type as lib::asio::error_code
     lib::error_code translate_ec(lib::error_code ec) {


### PR DESCRIPTION
This allows to give meaningful error messages when connection fails (at least when using compatible ASIO and `system::error_code`, see also #651).