### PR TITLE
Implemented rfc6555 to connect ipv4 and ipv6 addresses immediately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ Makefile
 bin
 
 Testing/Temporary/CTestCostData.txt
+.idea/
+cmake-build-*

--- a/websocketpp/common/asio.hpp
+++ b/websocketpp/common/asio.hpp
@@ -88,9 +88,6 @@ namespace lib {
         inline lib::chrono::milliseconds milliseconds(long duration) {
             return lib::chrono::milliseconds(duration);
         }
-        
-        } // namespace error
-        } // namespace ssl
     } // namespace asio
     
 #else

--- a/websocketpp/config/asio.hpp
+++ b/websocketpp/config/asio.hpp
@@ -65,6 +65,7 @@ struct asio_tls : public core {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef websocketpp::transport::asio::default_connector_polity connector_policy;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/asio_client.hpp
+++ b/websocketpp/config/asio_client.hpp
@@ -65,6 +65,7 @@ struct asio_tls_client : public core_client {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+        typedef websocketpp::transport::asio::default_connector_policy connector_policy;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/asio_no_tls.hpp
+++ b/websocketpp/config/asio_no_tls.hpp
@@ -61,6 +61,7 @@ struct asio : public core {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
+        typedef websocketpp::transport::asio::default_connector_policy connector_policy;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/config/asio_no_tls_client.hpp
+++ b/websocketpp/config/asio_no_tls_client.hpp
@@ -61,6 +61,7 @@ struct asio_client : public core_client {
         typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
+        typedef websocketpp::transport::asio::default_connector_policy connector_policy;
     };
 
     typedef websocketpp::transport::asio::endpoint<transport_config>

--- a/websocketpp/transport/asio/connection.hpp
+++ b/websocketpp/transport/asio/connection.hpp
@@ -1006,6 +1006,10 @@ protected:
         socket_con_type::set_handle(hdl);
     }
 
+    void set_socket(typename socket_con_type::socket_ptr socket) {
+        socket_con_type::set_socket(socket);
+    }
+
     /// Trigger the on_interrupt handler
     /**
      * This needs to be thread safe


### PR DESCRIPTION
The changes allow to make parallel connection attempts to endpoints and choose how to split it out.
The solution provides two strategies:
1) `websocketpp::transport::asio::default_connector_policy` which is used by default. It returns the range of endpoints as is to support previous implementation of connection - iterative attempts.
2) `websocketpp::transport::asio::rfc6555_connector_policy` - strategy based on the algorithm suggested by https://tools.ietf.org/html/rfc6555. It tries to connect to ipv4 and ipv6 addresses immediately and first win one is used for the connection.

The client could choose the policy using configs, for instance:
```
struct custom_config : public websocketpp::config::asio {
    ....
    struct transport_config : public websocketpp::config::asio::transport_config {
        ...
        using connector_policy = websocketpp::transport::asio::rfc6555_connector_policy;
    };
    using transport_type = websocketpp::transport::asio::endpoint<transport_config>;
};
```

The PR is referred to an issue https://github.com/zaphoyd/websocketpp/issues/656 **RFC6555 support**