### PR TITLE
do not pass nullptr connection to async_accept

### DIFF
--- a/websocketpp/roles/server_endpoint.hpp
+++ b/websocketpp/roles/server_endpoint.hpp
@@ -126,7 +126,12 @@ public:
         
         ec = lib::error_code();
         connection_ptr con = get_connection();
-        
+
+        if (!con) {
+            ec = error::make_error_code(error::con_creation_failed);
+            return;
+        }
+
         transport_type::async_accept(
             lib::static_pointer_cast<transport_con_type>(con),
             lib::bind(&type::handle_accept,this,con,lib::placeholders::_1),


### PR DESCRIPTION
the following sequence can cause a nullptr being propagated to async_accept in server_endpoint.hpp:

1. server::get_connection() calls endpoint::create_connection()
2. endpoint::create_connection() calls transport_type::init(con).
3. transport_type::init(con) returns an error
4. endpoint::create_connection() then returns a nullptr
5. server::get_connection() then returns nullptr 

step 3 can happen if the user defined tls init handler returns a nullptr in init_asio(...) in websocketpp/transport/asio/security/tls.hpp.