### PR TITLE
Make HTTP Connection header capitalized

### DIFF
--- a/websocketpp/processors/base.hpp
+++ b/websocketpp/processors/base.hpp
@@ -44,7 +44,7 @@ namespace processor {
 namespace constants {
 
 static char const upgrade_token[] = "websocket";
-static char const connection_token[] = "upgrade";
+static char const connection_token[] = "Upgrade";
 static char const handshake_guid[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 } // namespace constants


### PR DESCRIPTION
This is what other implementations do and what the example in [RFC 6455](https://tools.ietf.org/html/rfc6455#section-1.3) uses.

Apparently, no decent browser cares if this is uppercase or lowercase or whatever but apparently Edge (at least the version I have here) does and refuses to open a WebSocket connection otherwise.