### PR TITLE
cmake: Install websocketpp includes in the right cmake way, leaving o…

### DIFF
--- a/cmake/CMakeHelpers.cmake
+++ b/cmake/CMakeHelpers.cmake
@@ -79,12 +79,9 @@ macro (final_target)
                  CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
     endif ()
 
-    # install headers, directly from current source dir and look for subfolders with headers
-    file (GLOB_RECURSE TARGET_INSTALL_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.hpp)
-    foreach (hppfile ${TARGET_INSTALL_HEADERS})
-      get_filename_component (currdir ${hppfile} PATH)
-      install (FILES ${hppfile} DESTINATION "include/${TARGET_NAME}/${currdir}")
-    endforeach()
+    install (DIRECTORY ${CMAKE_SOURCE_DIR}/${TARGET_NAME}
+             DESTINATION include/
+             FILES_MATCHING PATTERN "*.hpp*")
 endmacro ()
 
 macro (link_boost)


### PR DESCRIPTION
…ut the examples and other stuff.

I had previously code to remove examples and other binaries from polluting /usr/include, better fix this in the right way

list of unwanted files, because they contained hpp files:
```
usr/include/echo_server/
usr/include/external_io_service 
usr/include/test_connection
```