### PR TITLE
remove some redundant definition to make it more easy to read

### DIFF
--- a/websocketpp/config/asio.hpp
+++ b/websocketpp/config/asio.hpp
@@ -44,26 +44,7 @@ struct asio_tls : public core {
     typedef asio_tls type;
     typedef core base;
 
-    typedef base::concurrency_type concurrency_type;
-
-    typedef base::request_type request_type;
-    typedef base::response_type response_type;
-
-    typedef base::message_type message_type;
-    typedef base::con_msg_manager_type con_msg_manager_type;
-    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
-
-    typedef base::alog_type alog_type;
-    typedef base::elog_type elog_type;
-
-    typedef base::rng_type rng_type;
-
     struct transport_config : public base::transport_config {
-        typedef type::concurrency_type concurrency_type;
-        typedef type::alog_type alog_type;
-        typedef type::elog_type elog_type;
-        typedef type::request_type request_type;
-        typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
     };
 

--- a/websocketpp/config/asio_client.hpp
+++ b/websocketpp/config/asio_client.hpp
@@ -44,26 +44,7 @@ struct asio_tls_client : public core_client {
     typedef asio_tls_client type;
     typedef core_client base;
 
-    typedef base::concurrency_type concurrency_type;
-
-    typedef base::request_type request_type;
-    typedef base::response_type response_type;
-
-    typedef base::message_type message_type;
-    typedef base::con_msg_manager_type con_msg_manager_type;
-    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
-
-    typedef base::alog_type alog_type;
-    typedef base::elog_type elog_type;
-
-    typedef base::rng_type rng_type;
-
     struct transport_config : public base::transport_config {
-        typedef type::concurrency_type concurrency_type;
-        typedef type::alog_type alog_type;
-        typedef type::elog_type elog_type;
-        typedef type::request_type request_type;
-        typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
     };
 

--- a/websocketpp/config/asio_no_tls.hpp
+++ b/websocketpp/config/asio_no_tls.hpp
@@ -39,26 +39,7 @@ struct asio : public core {
     typedef asio type;
     typedef core base;
 
-    typedef base::concurrency_type concurrency_type;
-
-    typedef base::request_type request_type;
-    typedef base::response_type response_type;
-
-    typedef base::message_type message_type;
-    typedef base::con_msg_manager_type con_msg_manager_type;
-    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
-
-    typedef base::alog_type alog_type;
-    typedef base::elog_type elog_type;
-
-    typedef base::rng_type rng_type;
-
     struct transport_config : public base::transport_config {
-        typedef type::concurrency_type concurrency_type;
-        typedef type::alog_type alog_type;
-        typedef type::elog_type elog_type;
-        typedef type::request_type request_type;
-        typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
     };

--- a/websocketpp/config/asio_no_tls_client.hpp
+++ b/websocketpp/config/asio_no_tls_client.hpp
@@ -39,26 +39,7 @@ struct asio_client : public core_client {
     typedef asio_client type;
     typedef core_client base;
 
-    typedef base::concurrency_type concurrency_type;
-
-    typedef base::request_type request_type;
-    typedef base::response_type response_type;
-
-    typedef base::message_type message_type;
-    typedef base::con_msg_manager_type con_msg_manager_type;
-    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
-
-    typedef base::alog_type alog_type;
-    typedef base::elog_type elog_type;
-
-    typedef base::rng_type rng_type;
-
     struct transport_config : public base::transport_config {
-        typedef type::concurrency_type concurrency_type;
-        typedef type::alog_type alog_type;
-        typedef type::elog_type elog_type;
-        typedef type::request_type request_type;
-        typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
     };

--- a/websocketpp/config/debug_asio.hpp
+++ b/websocketpp/config/debug_asio.hpp
@@ -44,26 +44,7 @@ struct debug_asio_tls : public debug_core {
     typedef debug_asio_tls type;
     typedef debug_core base;
 
-    typedef base::concurrency_type concurrency_type;
-
-    typedef base::request_type request_type;
-    typedef base::response_type response_type;
-
-    typedef base::message_type message_type;
-    typedef base::con_msg_manager_type con_msg_manager_type;
-    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
-
-    typedef base::alog_type alog_type;
-    typedef base::elog_type elog_type;
-
-    typedef base::rng_type rng_type;
-
     struct transport_config : public base::transport_config {
-        typedef type::concurrency_type concurrency_type;
-        typedef type::alog_type alog_type;
-        typedef type::elog_type elog_type;
-        typedef type::request_type request_type;
-        typedef type::response_type response_type;
         typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
     };
 

--- a/websocketpp/config/debug_asio_no_tls.hpp
+++ b/websocketpp/config/debug_asio_no_tls.hpp
@@ -39,26 +39,7 @@ struct debug_asio : public debug_core {
     typedef debug_asio type;
     typedef debug_core base;
 
-    typedef base::concurrency_type concurrency_type;
-
-    typedef base::request_type request_type;
-    typedef base::response_type response_type;
-
-    typedef base::message_type message_type;
-    typedef base::con_msg_manager_type con_msg_manager_type;
-    typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
-
-    typedef base::alog_type alog_type;
-    typedef base::elog_type elog_type;
-
-    typedef base::rng_type rng_type;
-
     struct transport_config : public base::transport_config {
-        typedef type::concurrency_type concurrency_type;
-        typedef type::alog_type alog_type;
-        typedef type::elog_type elog_type;
-        typedef type::request_type request_type;
-        typedef type::response_type response_type;
         typedef websocketpp::transport::asio::basic_socket::endpoint
             socket_type;
     };


### PR DESCRIPTION
Those config definitions include some typedef like concurrency_type,
request_type etc, while these definitions could be derived from parent
class.

This patch removes those redundant definition to make the audience easy to
catch which type is changed in child class.