### PR TITLE
Remove warnings on Microsoft Visual Studio with /W4

### DIFF
--- a/websocketpp/common/md5.hpp
+++ b/websocketpp/common/md5.hpp
@@ -364,7 +364,7 @@ void md5_append(md5_state_t *pms, md5_byte_t const * data, size_t nbytes) {
     return;
 
     /* Update the message length. */
-    pms->count[1] += nbytes >> 29;
+    pms->count[1] += static_cast<md5_word_t>(nbytes >> 29);
     pms->count[0] += nbits;
     if (pms->count[0] < nbits)
     pms->count[1]++;

--- a/websocketpp/frame.hpp
+++ b/websocketpp/frame.hpp
@@ -234,17 +234,29 @@ struct basic_header {
 /// The variable size component of a WebSocket frame header
 struct extended_header {
     extended_header() {
-        std::fill_n(this->bytes,MAX_EXTENDED_HEADER_LENGTH,0x00);
+        std::fill_n(
+            this->bytes,
+            static_cast<uint8_t>(MAX_EXTENDED_HEADER_LENGTH),
+            uint8_t(0x00)
+        );
     }
 
     extended_header(uint64_t payload_size) {
-        std::fill_n(this->bytes,MAX_EXTENDED_HEADER_LENGTH,0x00);
+        std::fill_n(
+            this->bytes,
+            static_cast<uint8_t>(MAX_EXTENDED_HEADER_LENGTH),
+            uint8_t(0x00)
+        );
 
         copy_payload(payload_size);
     }
 
     extended_header(uint64_t payload_size, uint32_t masking_key) {
-        std::fill_n(this->bytes,MAX_EXTENDED_HEADER_LENGTH,0x00);
+        std::fill_n(
+            this->bytes,
+            static_cast<uint8_t>(MAX_EXTENDED_HEADER_LENGTH),
+            uint8_t(0x00)
+        );
 
         // Copy payload size
         int offset = copy_payload(payload_size);
@@ -831,7 +843,7 @@ inline size_t byte_mask_circ(uint8_t * input, uint8_t * output, size_t length,
     size_t prepared_key)
 {
     uint32_converter key;
-    key.i = prepared_key;
+    key.i = static_cast<uint32_t>(prepared_key);
 
     for (size_t i = 0; i < length; ++i) {
         output[i] = input[i] ^ key.c[i % 4];

--- a/websocketpp/impl/utilities_impl.hpp
+++ b/websocketpp/impl/utilities_impl.hpp
@@ -36,7 +36,12 @@ namespace utility {
 
 inline std::string to_lower(std::string const & in) {
     std::string out = in;
-    std::transform(out.begin(),out.end(),out.begin(),::tolower);
+    std::transform(
+        out.begin(),
+        out.end(),
+        out.begin(),
+        [](char c) { return static_cast<char>(::tolower(c)); }
+    );
     return out;
 }
 

--- a/websocketpp/processors/hybi00.hpp
+++ b/websocketpp/processors/hybi00.hpp
@@ -435,7 +435,7 @@ private:
                       reinterpret_cast<char*>(&num)+4,
                       result);
         } else {
-            std::fill(result,result+4,0);
+            std::fill(result,result+4,char(0));
         }
     }
 

--- a/websocketpp/processors/hybi13.hpp
+++ b/websocketpp/processors/hybi13.hpp
@@ -554,8 +554,8 @@ public:
 
         std::fill_n(
             m_extended_header.bytes,
-            frame::MAX_EXTENDED_HEADER_LENGTH,
-            0x00
+            static_cast<uint8_t>(frame::MAX_EXTENDED_HEADER_LENGTH),
+            uint8_t(0x00)
         );
     }
 

--- a/websocketpp/sha1/sha1.hpp
+++ b/websocketpp/sha1/sha1.hpp
@@ -173,7 +173,7 @@ inline void calc(void const * src, size_t bytelength, unsigned char * hash) {
         innerHash(result, w);
         clearWBuffert(w);
     }
-    w[15] = bytelength << 3;
+    w[15] = static_cast<unsigned int>(bytelength << 3);
     innerHash(result, w);
 
     // Store hash in result pointer, and make sure we get in in the correct


### PR DESCRIPTION
A number of conversion errors are generated when including headers in projects compiled with /W4 warning level on Visual Studio 2017. This pull requests removes these warnings by explicitly stating the required conversions.


Crossreference: https://github.com/OpenSpace/OpenSpace/issues/708