### PR TITLE
Fix "include" directory installation.

### DIFF
--- a/cmake/CMakeHelpers.cmake
+++ b/cmake/CMakeHelpers.cmake
@@ -80,7 +80,7 @@ macro (final_target)
     endif ()
 
     install (DIRECTORY ${CMAKE_SOURCE_DIR}/${TARGET_NAME}
-             DESTINATION include/
+             DESTINATION ${INSTALL_INCLUDE_DIR}/
              FILES_MATCHING PATTERN "*.hpp*")
 endmacro ()
 


### PR DESCRIPTION
the variable INSTALL_INCLUDE_DIR already exists, and defaults to include if not specificied otherwise.
Using it allows people to customize the installation from outside, fixing issues with other OS like Haiku

Signed-off-by: Gianfranco Costamagna <costamagnagianfranco@yahoo.it>
Signed-off-by: Gianfranco Costamagna <locutusofborg@debian.org>