### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: cpp
 compiler:
   - gcc
-before_install:
- #- sudo apt-get install libboost-chrono1.48-dev libboost-regex1.48-dev libboost-system1.48-dev libboost-thread1.48-dev libboost-test1.48-dev libboost-random1.48-dev -y
- - sudo add-apt-repository -y ppa:boost-latest/ppa && sudo apt-get update -q && sudo apt-get install -y libboost-chrono1.55-dev libboost-random1.55-dev libboost-regex1.55-dev libboost-system1.55-dev libboost-thread1.55-dev libboost-test1.55-dev
+addons:
+  apt:
+    packages:
+      - libboost-random1.58-dev
+      - libboost-system1.58-dev
+      - libboost-test1.58-dev
+      - libboost-thread1.58-dev
+      - scons
 env:
   global:
     - BOOST_INCLUDES=/usr/include

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
     - BOOST_INCLUDES=/usr/include
     - BOOST_LIBS=/usr/lib/x86_64-linux-gnu
 script: scons -j 2 && scons test
-branches:
-  only:
-    - master
-    - develop
 notifications:
   recipients:
     - travis@zaphoyd.com


### PR DESCRIPTION
Boost on ppa:boost-latest hasn't been updated since 2014 and doesn't support the new default OS (xenial) on Travis.

See: https://launchpad.net/~boost-latest/+archive/ubuntu/ppa