### PR TITLE
Add license type

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,7 @@
 Main Library:
 
+BSD 3-Clause License
+
 Copyright (c) 2014, Peter Thorson. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Trying to on-board this software into a large corporation.  The powers that control this process are unable to recognize this license as BSD-3 without it explicitly saying that it's BSD3.