### PR TITLE
Fix possible `std::errc` misuse with standalone Asio

### DIFF
--- a/websocketpp/common/asio.hpp
+++ b/websocketpp/common/asio.hpp
@@ -72,10 +72,6 @@ namespace lib {
 #ifdef ASIO_STANDALONE
     namespace asio {
         using namespace ::asio;
-        // Here we assume that we will be using std::error_code with standalone
-        // Asio. This is probably a good assumption, but it is possible in rare
-        // cases that local Asio versions would be used.
-        using std::errc;
         
         // See note above about boost <1.49 compatibility. Because we require
         // a standalone Asio version of 1.8+ we are guaranteed to have 
@@ -130,7 +126,6 @@ namespace lib {
         #endif
         
         using boost::system::error_code;
-        namespace errc = boost::system::errc;
     } // namespace asio
 #endif
 

--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -833,7 +833,7 @@ protected:
         m_alog->write(log::alevel::devel, "asio::handle_accept");
 
         if (asio_ec) {
-            if (asio_ec == lib::asio::errc::operation_canceled) {
+            if (asio_ec == lib::asio::error::operation_aborted) {
                 ret_ec = make_error_code(websocketpp::error::operation_canceled);
             } else {
                 log_err(log::elevel::info,"asio handle_accept",asio_ec);


### PR DESCRIPTION
* Always use error codes from `asio::error::*`, not `errc::*`
* Remove confusing `errc` from `websocket::lib` namespace

When using boost asio, this is a non-issue, since `asio::error_code` uses
the same error category as `boost::system::errc`. When using standalone
asio, asio defines its own error category incompatible with std one,
which causes such comparisons to always fail.