### PR TITLE
Mark `endpoint::get_con_from_hdl` as const

### DIFF
--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -640,7 +640,7 @@ public:
      *
      * @return the connection_ptr. May be NULL if the handle was invalid.
      */
-    connection_ptr get_con_from_hdl(connection_hdl hdl, lib::error_code & ec) {
+    connection_ptr get_con_from_hdl(connection_hdl hdl, lib::error_code & ec) const {
         connection_ptr con = lib::static_pointer_cast<connection_type>(
             hdl.lock());
         if (!con) {
@@ -650,7 +650,7 @@ public:
     }
 
     /// Retrieves a connection_ptr from a connection_hdl (exception version)
-    connection_ptr get_con_from_hdl(connection_hdl hdl) {
+    connection_ptr get_con_from_hdl(connection_hdl hdl) const {
         lib::error_code ec;
         connection_ptr con = this->get_con_from_hdl(hdl,ec);
         if (ec) {


### PR DESCRIPTION
I wasn't able to call `get_con_from_hdl` from a `const websocketpp::server&`, and that seemed like something I should be able to do. This is a minor change, but would be really nice to have.