### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,16 @@ addons:
 env:
   global:
     - BOOST_INCLUDES=/usr/include
-    - BOOST_LIBS=/usr/lib/x86_64-linux-gnu
+    
+matrix:
+ include:
+    - arch: amd64
+      env:
+       - BOOST_LIBS=/usr/lib/x86_64-linux-gnu
+    - arch: ppc64le
+      env: 
+       - BOOST_LIBS=/usr/lib/powerpc64le-linux-gnu
+
 script: cmake -DBUILD_EXAMPLES=1 -DBUILD_TESTS=1 . && make -j 2 && make test
 branches:
   except:


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) , detecting (and fixing) any issues or failures early would help to ensure that we are always up to date. 