### PR TITLE
Safer std::string to_lower(std::string)

### DIFF
--- a/websocketpp/impl/utilities_impl.hpp
+++ b/websocketpp/impl/utilities_impl.hpp
@@ -36,7 +36,7 @@ namespace utility {
 
 inline std::string to_lower(std::string const & in) {
     std::string out = in;
-    std::transform(out.begin(),out.end(),out.begin(),::tolower);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c)->char { return static_cast<char>(std::tolower(c)); });
     return out;
 }
 


### PR DESCRIPTION
I did this modification due to a warning message by MSVC. Anyway, a conversion of std::string to lower case with standard algorithms shall treat characters as unsigned type, which is described here: https://en.cppreference.com/w/cpp/string/byte/tolower
Therefore, instead of
```
std::transform(out.begin(),out.end(),out.begin(),::tolower);
```
we should use
```
std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c)->char { return static_cast<char>(std::tolower(c)); });
```

