### PR TITLE
Change copy constructor of endpoint to const &

### DIFF
--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -113,7 +113,7 @@ public:
 
     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
         // no copy constructor because endpoints are not copyable
-        endpoint(endpoint &) = delete;
+        endpoint(endpoint const &) = delete;
     
         // no copy assignment operator because endpoints are not copyable
         endpoint & operator=(endpoint const &) = delete;


### PR DESCRIPTION
Fix a compilation error when I use the `websocketpp::client` in a `std::variant` using `libc++`. `lbstdc++` works fine.

**Example of code that does not compile using `libc++`**

```

#include <websocketpp/config/asio_no_tls_client.hpp>
#include <websocketpp/config/asio_client.hpp>
#include <websocketpp/client.hpp>
#include <variant>

class WebSocketClient
{
    using WsClient = websocketpp::client<websocketpp::config::asio_client>;
    using WssClient = websocketpp::client<websocketpp::config::asio_tls_client>;

    std::variant<WssClient, WsClient> websocketClient;
};

```

**Compilation error:**

```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/variant:716:1: error: the parameter for this explicitly-defaulted copy constructor is const, but a member or base requires it to be non-const
_LIBCPP_VARIANT_UNION(_Trait::_Available, ~__union() {});
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/variant:699:5: note: expanded from macro '_LIBCPP_VARIANT_UNION'
    __union(const __union&) = default;                                         \
    ^

...
    
                                  ^
In file included from /Users/ricardo.domingues/my-project/src/WebSocketClient.cpp:6:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/usr/include/c++/v1/variant:716:1: error: the parameter for this explicitly-defaulted copy constructor is const, but a member or base requires it to be non-const
_LIBCPP_VARIANT_UNION(_Trait::_Available, ~__union() {});
```