### PR TITLE
SCons 4.2.0 no longer has env_cpp11.has_key()

### DIFF
--- a/examples/broadcast_server/SConscript
+++ b/examples/broadcast_server/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('broadcast_server', ["broadcast_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/debug_client/SConscript
+++ b/examples/debug_client/SConscript
@@ -14,7 +14,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs]
    prgs += env_cpp11.Program('debug_client', ["debug_client.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/debug_server/SConscript
+++ b/examples/debug_server/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('debug_server', ["debug_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/dev/SConscript
+++ b/examples/dev/SConscript
@@ -11,7 +11,7 @@ env_cpp11 = env_cpp11.Clone ()
 
 prgs = []
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework','system','timer','chrono'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('main', ["main.cpp"], LIBS = BOOST_LIBS_CPP11)
 

--- a/examples/echo_client/SConscript
+++ b/examples/echo_client/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + ['z']
    prgs += env_cpp11.Program('echo_client', ["echo_client.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/echo_server/SConscript
+++ b/examples/echo_server/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('echo_server', ["echo_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/echo_server_both/SConscript
+++ b/examples/echo_server_both/SConscript
@@ -14,7 +14,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs]
    prgs += env_cpp11.Program('echo_server_both', ["echo_server_both.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/echo_server_tls/SConscript
+++ b/examples/echo_server_tls/SConscript
@@ -14,7 +14,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs]
    prgs += env_cpp11.Program('echo_server_tls', ["echo_server_tls.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/external_io_service/SConscript
+++ b/examples/external_io_service/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('external_io_service', ["external_io_service.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/iostream_server/SConscript
+++ b/examples/iostream_server/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('iostream_server', ["iostream_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/print_client/SConscript
+++ b/examples/print_client/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('print_client', ["print_client.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/print_client_tls/SConscript
+++ b/examples/print_client_tls/SConscript
@@ -14,7 +14,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs]
    prgs += env_cpp11.Program('print_client_tls', ["print_client_tls.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/print_server/SConscript
+++ b/examples/print_server/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('print_server', ["print_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/scratch_client/SConscript
+++ b/examples/scratch_client/SConscript
@@ -14,7 +14,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs]
    prgs += env_cpp11.Program('scratch_client', ["scratch_client.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/scratch_server/SConscript
+++ b/examples/scratch_server/SConscript
@@ -14,7 +14,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs] + ['z']
    prgs += env_cpp11.Program('scratch_server', ["scratch_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/sip_client/SConscript
+++ b/examples/sip_client/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('sip_client', ["sip_client.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/subprotocol_server/SConscript
+++ b/examples/subprotocol_server/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('subprotocol_server', ["subprotocol_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/telemetry_client/SConscript
+++ b/examples/telemetry_client/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('telemetry_client', ["telemetry_client.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/telemetry_server/SConscript
+++ b/examples/telemetry_server/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('telemetry_server', ["telemetry_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/testee_client/SConscript
+++ b/examples/testee_client/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + ['z']
    prgs += env_cpp11.Program('testee_client', ["testee_client.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/testee_server/SConscript
+++ b/examples/testee_server/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs] + ['z']
    prgs += env_cpp11.Program('testee_server', ["testee_server.cpp"], LIBS = ALL_LIBS)
 else:

--- a/examples/utility_client/SConscript
+++ b/examples/utility_client/SConscript
@@ -13,7 +13,7 @@ env_cpp11 = env_cpp11.Clone ()
 prgs = []
 
 # if a C++11 environment is available build using that, otherwise use boost
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    ALL_LIBS = boostlibs(['system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    prgs += env_cpp11.Program('utility_client', ["utility_client.cpp"], LIBS = ALL_LIBS)
 else:

--- a/test/connection/SConscript
+++ b/test/connection/SConscript
@@ -16,7 +16,7 @@ objs = env.Object('connection_boost.o', ["connection.cpp"], LIBS = BOOST_LIBS)
 objs = env.Object('connection_tu2_boost.o', ["connection_tu2.cpp"], LIBS = BOOST_LIBS)
 prgs = env.Program('test_connection_boost', ["connection_boost.o","connection_tu2_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework','system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    objs += env_cpp11.Object('connection_stl.o', ["connection.cpp"], LIBS = BOOST_LIBS_CPP11)
    objs += env_cpp11.Object('connection_tu2_stl.o', ["connection_tu2.cpp"], LIBS = BOOST_LIBS_CPP11)

--- a/test/endpoint/SConscript
+++ b/test/endpoint/SConscript
@@ -16,7 +16,7 @@ BOOST_LIBS = boostlibs(['unit_test_framework','system'],env) + [platform_libs] +
 objs = env.Object('endpoint_boost.o', ["endpoint.cpp"], LIBS = BOOST_LIBS)
 prgs = env.Program('test_endpoint_boost', ["endpoint_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework','system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs]
    objs += env_cpp11.Object('endpoint_stl.o', ["endpoint.cpp"], LIBS = BOOST_LIBS_CPP11)
    prgs += env_cpp11.Program('test_endpoint_stl', ["endpoint_stl.o"], LIBS = BOOST_LIBS_CPP11)

--- a/test/extension/SConscript
+++ b/test/extension/SConscript
@@ -17,7 +17,7 @@ objs += env.Object('permessage_deflate_boost.o', ["permessage_deflate.cpp"], LIB
 prgs = env.Program('test_extension_boost', ["extension_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_permessage_deflate_boost', ["permessage_deflate_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework'],env_cpp11) + [platform_libs] + [polyfill_libs] + ['z']
    objs += env_cpp11.Object('extension_stl.o', ["extension.cpp"], LIBS = BOOST_LIBS_CPP11)
    objs += env_cpp11.Object('permessage_deflate_stl.o', ["permessage_deflate.cpp"], LIBS = BOOST_LIBS_CPP11)

--- a/test/http/SConscript
+++ b/test/http/SConscript
@@ -15,7 +15,7 @@ BOOST_LIBS = boostlibs(['unit_test_framework'],env) + [platform_libs]
 objs = env.Object('parser_boost.o', ["parser.cpp"], LIBS = BOOST_LIBS)
 prgs = env.Program('test_http_boost', ["parser_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework'],env_cpp11) + [platform_libs] + [polyfill_libs]
    objs += env_cpp11.Object('parser_stl.o', ["parser.cpp"], LIBS = BOOST_LIBS_CPP11)
    prgs += env_cpp11.Program('test_http_stl', ["parser_stl.o"], LIBS = BOOST_LIBS_CPP11)

--- a/test/logger/SConscript
+++ b/test/logger/SConscript
@@ -15,7 +15,7 @@ BOOST_LIBS = boostlibs(['unit_test_framework','system'],env) + [platform_libs]
 objs = env.Object('logger_basic_boost.o', ["basic.cpp"], LIBS = BOOST_LIBS)
 prgs = env.Program('logger_basic_boost', ["logger_basic_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework','system'],env_cpp11) + [platform_libs] + [polyfill_libs]
    objs += env_cpp11.Object('logger_basic_stl.o', ["basic.cpp"], LIBS = BOOST_LIBS_CPP11)
    prgs += env_cpp11.Program('logger_basic_stl', ["logger_basic_stl.o"], LIBS = BOOST_LIBS_CPP11)

--- a/test/message_buffer/SConscript
+++ b/test/message_buffer/SConscript
@@ -17,7 +17,7 @@ objs += env.Object('alloc_boost.o', ["alloc.cpp"], LIBS = BOOST_LIBS)
 prgs = env.Program('test_message_boost', ["message_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_alloc_boost', ["alloc_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework'],env_cpp11) + [platform_libs] + [polyfill_libs]
    objs += env_cpp11.Object('message_stl.o', ["message.cpp"], LIBS = BOOST_LIBS_CPP11)
    objs += env_cpp11.Object('alloc_stl.o', ["alloc.cpp"], LIBS = BOOST_LIBS_CPP11)

--- a/test/processors/SConscript
+++ b/test/processors/SConscript
@@ -26,7 +26,7 @@ prgs += env.Program('test_hybi07_boost', ["test_hybi07_boost.o"], LIBS = BOOST_L
 prgs += env.Program('test_hybi00_boost', ["test_hybi00_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_extension_permessage_compress_boost', ["test_extension_permessage_compress_boost.o"], LIBS = BOOST_LIBS + ['z'])
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework'],env_cpp11) + [platform_libs] + [polyfill_libs] + ['z']
    # no C++11 features are used in processor so there are no C++11 versions of
    # these tests.

--- a/test/random/SConscript
+++ b/test/random/SConscript
@@ -17,7 +17,7 @@ objs += env.Object('random_device_boost.o', ["random_device.cpp"], LIBS = BOOST_
 prgs = env.Program('test_random_none_boost', ["random_none_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_random_device_boost', ["random_device_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework'],env_cpp11) + [platform_libs] + [polyfill_libs]
    objs += env_cpp11.Object('random_none_stl.o', ["none.cpp"], LIBS = BOOST_LIBS_CPP11)
    objs += env_cpp11.Object('random_device_stl.o', ["random_device.cpp"], LIBS = BOOST_LIBS_CPP11)

--- a/test/roles/SConscript
+++ b/test/roles/SConscript
@@ -17,7 +17,7 @@ objs += env.Object('server_boost.o', ["server.cpp"], LIBS = BOOST_LIBS)
 prgs = env.Program('test_client_boost', ["client_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_server_boost', ["server_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework'],env_cpp11) + [platform_libs] + [polyfill_libs]
    objs += env_cpp11.Object('client_stl.o', ["client.cpp"], LIBS = BOOST_LIBS_CPP11)
    objs += env_cpp11.Object('server_stl.o', ["server.cpp"], LIBS = BOOST_LIBS_CPP11)

--- a/test/transport/SConscript
+++ b/test/transport/SConscript
@@ -16,7 +16,7 @@ BOOST_LIBS = boostlibs(['unit_test_framework','system','thread','random','chrono
 objs = env.Object('boost_integration.o', ["integration.cpp"], LIBS = BOOST_LIBS)
 prgs = env.Program('test_boost_integration', ["boost_integration.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework','system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs]
    objs += env_cpp11.Object('stl_integration.o', ["integration.cpp"], LIBS = BOOST_LIBS_CPP11)
    prgs += env_cpp11.Program('test_stl_integration', ["stl_integration.o"], LIBS = BOOST_LIBS_CPP11)

--- a/test/transport/asio/SConscript
+++ b/test/transport/asio/SConscript
@@ -20,7 +20,7 @@ prgs = env.Program('test_base_boost', ["base_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_timers_boost', ["timers_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_security_boost', ["security_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework','system'],env_cpp11) + [platform_libs] + [polyfill_libs] + [tls_libs]
    objs += env_cpp11.Object('base_stl.o', ["base.cpp"], LIBS = BOOST_LIBS_CPP11)
    objs += env_cpp11.Object('timers_stl.o', ["timers.cpp"], LIBS = BOOST_LIBS_CPP11)

--- a/test/transport/iostream/SConscript
+++ b/test/transport/iostream/SConscript
@@ -19,7 +19,7 @@ prgs = env.Program('test_iostream_base_boost', ["iostream_base_boost.o"], LIBS =
 prgs += env.Program('test_iostream_connection_boost', ["iostream_connection_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_iostream_endpoint_boost', ["iostream_endpoint_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework'],env_cpp11) + [platform_libs] + [polyfill_libs]
    objs += env_cpp11.Object('iostream_base_stl.o', ["base.cpp"], LIBS = BOOST_LIBS_CPP11)
    objs += env_cpp11.Object('iostream_connection_stl.o', ["connection.cpp"], LIBS = BOOST_LIBS_CPP11)

--- a/test/utility/SConscript
+++ b/test/utility/SConscript
@@ -24,7 +24,7 @@ prgs += env.Program('test_close_boost', ["close_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_sha1_boost', ["sha1_boost.o"], LIBS = BOOST_LIBS)
 prgs += env.Program('test_error_boost', ["error_boost.o"], LIBS = BOOST_LIBS)
 
-if env_cpp11.has_key('WSPP_CPP11_ENABLED'):
+if 'WSPP_CPP11_ENABLED' in env_cpp11:
    BOOST_LIBS_CPP11 = boostlibs(['unit_test_framework'],env_cpp11) + [platform_libs] + [polyfill_libs]
    objs += env_cpp11.Object('utilities_stl.o', ["utilities.cpp"], LIBS = BOOST_LIBS_CPP11)
    objs += env_cpp11.Object('uri_stl.o', ["uri.cpp"], LIBS = BOOST_LIBS_CPP11)


### PR DESCRIPTION
Check env_cpp11 as an array.

This fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003022