### PR TITLE
Add this_thread namespace

### DIFF
--- a/websocketpp/common/thread.hpp
+++ b/websocketpp/common/thread.hpp
@@ -63,6 +63,7 @@
     #include <boost/thread.hpp>
     #include <boost/thread/mutex.hpp>
     #include <boost/thread/condition_variable.hpp>
+    #include <boost/thread/thread.hpp>
 #endif
 
 namespace websocketpp {
@@ -74,12 +75,14 @@ namespace lib {
     using std::thread;
     using std::unique_lock;
     using std::condition_variable;
+    namespace this_thread = std::this_thread;
 #else
     using boost::mutex;
     using boost::lock_guard;
     using boost::thread;
     using boost::unique_lock;
     using boost::condition_variable;
+    namespace this_thread = boost::this_thread;
 #endif
 
 } // namespace lib


### PR DESCRIPTION
First and foremost, thank you for this gread lib. In the current project, I have to make a call to this_thread::sleep_for() in parts of the implementation (using a separate thread for endpoint). In order to respect the current design that makes a distinction between boost and stl, I've added a quick patch in my code that looks something like this:

```
#ifndef _WEBSOCKETPP_CPP11_STL_
#include <boost/thread/thread.hpp>
#endif

...

namespace websocketpp {
namespace lib {
#ifdef _WEBSOCKETPP_CPP11_STL_
namespace this_thread = std::this_thread;
#else
namespace this_thread = boost::this_thread;
#endif
} // namespace lib
} // namespace websocketpp

...

websocketpp::lib::this_thread::sleep_for(websocketpp::lib::chrono::milliseconds(1000));
```

Ideally, I'd see this as code that thread.hpp would take care of, which is exactly the goal of this PR.