### PR TITLE
[cmake] upgrade cmake version to eliminate deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 ############ Setup project and cmake
 # Minimum cmake requirement. We should require a quite recent
 # cmake for the dependency find macros etc. to be up to date.
-cmake_minimum_required (VERSION 2.8.8)
+cmake_minimum_required (VERSION 2.8.12)
 
 ############ Paths
 


### PR DESCRIPTION
when I use websocktpp in my project, then comes camke version warning:

C/C++: debug|arm64-v8a :CMake Deprecation Warning at D:/Hippy/driver/js/android/.cxx/Debug/2e504n4g/arm64-v8a/_deps/websocketpp-src/CMakeLists.txt:5 (cmake_minimum_required):
C/C++: debug|arm64-v8a :  Compatibility with CMake < 2.8.12 will be removed from a future version of
C/C++: debug|arm64-v8a :  CMake.
C/C++: debug|arm64-v8a :  Update the VERSION argument <min> value or use a ...<max> suffix to tell
C/C++: debug|arm64-v8a :  CMake that the project does not need compatibility with older versions.

so should we upgrade cmake version to 2.8.12