### PR TITLE
remove template-id from ctors and dtors

### DIFF
--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -109,7 +109,7 @@ public:
 
 
     /// Destructor
-    ~endpoint<connection,config>() {}
+	~endpoint() {}
 
     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
         // no copy constructor because endpoints are not copyable

--- a/websocketpp/logger/basic.hpp
+++ b/websocketpp/logger/basic.hpp
@@ -58,33 +58,33 @@ namespace log {
 template <typename concurrency, typename names>
 class basic {
 public:
-    basic<concurrency,names>(channel_type_hint::value h =
+	basic(channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
 
-    basic<concurrency,names>(std::ostream * out)
+	basic(std::ostream * out)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(out) {}
 
-    basic<concurrency,names>(level c, channel_type_hint::value h =
+	basic(level c, channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
 
-    basic<concurrency,names>(level c, std::ostream * out)
+	basic(level c, std::ostream * out)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(out) {}
 
     /// Destructor
-    ~basic<concurrency,names>() {}
+	~basic() {}
 
     /// Copy constructor
-    basic<concurrency,names>(basic<concurrency,names> const & other)
+	basic(basic<concurrency,names> const & other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)
@@ -97,7 +97,7 @@ public:
 
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
     /// Move constructor
-    basic<concurrency,names>(basic<concurrency,names> && other)
+	basic(basic<concurrency,names> && other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)

--- a/websocketpp/logger/syslog.hpp
+++ b/websocketpp/logger/syslog.hpp
@@ -51,7 +51,7 @@ public:
     /**
      * @param hint A channel type specific hint for how to construct the logger
      */
-    syslog<concurrency,names>(channel_type_hint::value hint =
+    syslog(channel_type_hint::value hint =
         channel_type_hint::access)
       : basic<concurrency,names>(hint), m_channel_type_hint(hint) {}
 
@@ -60,7 +60,7 @@ public:
      * @param channels A set of channels to statically enable
      * @param hint A channel type specific hint for how to construct the logger
      */
-    syslog<concurrency,names>(level channels, channel_type_hint::value hint =
+    syslog(level channels, channel_type_hint::value hint =
         channel_type_hint::access)
       : basic<concurrency,names>(channels, hint), m_channel_type_hint(hint) {}
 


### PR DESCRIPTION
template-id is not allowed in ctor/dtor. It also fixed compilation with GCC 11