### PR TITLE
mark argument of endpoint copy constructor as const to allow for constructing in libc++ std::varaint

### DIFF
--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -113,7 +113,7 @@ public:
 
     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
         // no copy constructor because endpoints are not copyable
-        endpoint(endpoint &) = delete;
+        endpoint(const endpoint &) = delete;
     
         // no copy assignment operator because endpoints are not copyable
         endpoint & operator=(endpoint const &) = delete;


### PR DESCRIPTION
In libc++, apparently deleted copy constructors are required to have a const argument to be able to be put in std::varaint.

Currently, 

```c++
typedef websocketpp::client<websocketpp::config::asio_client> client;
std::variant<std::monostate, client> asdf;
```

fails to build with

<details>
  <summary>output</summary>

  ```
/usr/bin/clang++ -DBOOST_RANDOM_DYN_LINK -DBOOST_RANDOM_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_TEST_DYN_LINK -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DNDEBUG -D_WEBSOCKETPP_CPP11_STL_ -I/home/russell/websocketpp/examples/echo_client -I/home/russell/websocketpp -I/home/russell/websocketpp/websocketpp -stdlib=libc++ -std=c++17   -Wall -Wno-padded -MD -MT examples/echo_client/CMakeFiles/echo_client.dir/echo_client.cpp.o -MF examples/echo_client/CMakeFiles/echo_client.dir/echo_client.cpp.o.d -o examples/echo_client/CMakeFiles/echo_client.dir/echo_client.cpp.o -c /home/russell/websocketpp/examples/echo_client/echo_client.cpp
In file included from /home/russell/websocketpp/examples/echo_client/echo_client.cpp:28:
In file included from /home/russell/websocketpp/websocketpp/config/asio_no_tls_client.hpp:31:
In file included from /home/russell/websocketpp/websocketpp/config/core_client.hpp:38:
In file included from /home/russell/websocketpp/websocketpp/concurrency/basic.hpp:31:
In file included from /home/russell/websocketpp/websocketpp/common/thread.hpp:59:
In file included from /usr/bin/../include/c++/v1/thread:88:
In file included from /usr/bin/../include/c++/v1/__mutex_base:17:
In file included from /usr/bin/../include/c++/v1/system_error:151:
In file included from /usr/bin/../include/c++/v1/string:525:
In file included from /usr/bin/../include/c++/v1/algorithm:667:
In file included from /usr/bin/../include/c++/v1/functional:506:
In file included from /usr/bin/../include/c++/v1/__functional/function.h:24:
In file included from /usr/bin/../include/c++/v1/memory:819:
In file included from /usr/bin/../include/c++/v1/__memory/ranges_uninitialized_algorithms.h:22:
In file included from /usr/bin/../include/c++/v1/__memory/uninitialized_algorithms.h:17:
In file included from /usr/bin/../include/c++/v1/iterator:591:
In file included from /usr/bin/../include/c++/v1/__iterator/common_iterator.h:22:
/usr/bin/../include/c++/v1/variant:757:1: error: the parameter for this explicitly-defaulted copy constructor is const, but a member or base requires it to be non-const
_LIBCPP_VARIANT_UNION(_Trait::_Available, ~__union() {});
^
/usr/bin/../include/c++/v1/variant:740:5: note: expanded from macro '_LIBCPP_VARIANT_UNION'
    __union(const __union&) = default;                                         \
    ^
/usr/bin/../include/c++/v1/variant:757:1: note: in instantiation of template class 'std::__variant_detail::__union<std::__variant_detail::_Trait::_Available, 1, websocketpp::client<websocketpp::config::asio_client>>' requested here
/usr/bin/../include/c++/v1/variant:751:56: note: expanded from macro '_LIBCPP_VARIANT_UNION'
    __union<destructible_trait, _Index + 1, _Types...> __tail;                 \
                                                       ^
/usr/bin/../include/c++/v1/variant:804:45: note: in instantiation of template class 'std::__variant_detail::__union<std::__variant_detail::_Trait::_Available, 0, std::monostate, websocketpp::client<websocketpp::config::asio_client>>' requested here
  __union<_DestructibleTrait, 0, _Types...> __data;
                                            ^
/usr/bin/../include/c++/v1/variant:842:1: note: in instantiation of template class 'std::__variant_detail::__base<std::__variant_detail::_Trait::_Available, std::monostate, websocketpp::client<websocketpp::config::asio_client>>' requested here
_LIBCPP_VARIANT_DESTRUCTOR(
^
/usr/bin/../include/c++/v1/variant:818:16: note: expanded from macro '_LIBCPP_VARIANT_DESTRUCTOR'
      : public __base<destructible_trait, _Types...> {                         \
               ^
/usr/bin/../include/c++/v1/variant:865:44: note: in instantiation of template class 'std::__variant_detail::__dtor<std::__variant_detail::__traits<std::monostate, websocketpp::client<websocketpp::config::asio_client>>, std::__variant_detail::_Trait::_Available>' requested here
class _LIBCPP_TEMPLATE_VIS __ctor : public __dtor<_Traits> {
                                           ^
/usr/bin/../include/c++/v1/variant:925:1: note: in instantiation of template class 'std::__variant_detail::__ctor<std::__variant_detail::__traits<std::monostate, websocketpp::client<websocketpp::config::asio_client>>>' requested here
_LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
^
/usr/bin/../include/c++/v1/variant:907:16: note: expanded from macro '_LIBCPP_VARIANT_MOVE_CONSTRUCTOR'
      : public __ctor<__traits<_Types...>> {                                   \
               ^
/usr/bin/../include/c++/v1/variant:972:1: note: (skipping 2 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
_LIBCPP_VARIANT_COPY_CONSTRUCTOR(
^
/usr/bin/../include/c++/v1/variant:947:16: note: expanded from macro '_LIBCPP_VARIANT_COPY_CONSTRUCTOR'
      : public __move_constructor<__traits<_Types...>> {                       \
               ^
/usr/bin/../include/c++/v1/variant:1073:1: note: in instantiation of template class 'std::__variant_detail::__assignment<std::__variant_detail::__traits<std::monostate, websocketpp::client<websocketpp::config::asio_client>>>' requested here
_LIBCPP_VARIANT_MOVE_ASSIGNMENT(
^
/usr/bin/../include/c++/v1/variant:1046:16: note: expanded from macro '_LIBCPP_VARIANT_MOVE_ASSIGNMENT'
      : public __assignment<__traits<_Types...>> {                             \
               ^
/usr/bin/../include/c++/v1/variant:1112:1: note: in instantiation of template class 'std::__variant_detail::__move_assignment<std::__variant_detail::__traits<std::monostate, websocketpp::client<websocketpp::config::asio_client>>, std::__variant_detail::_Trait::_Unavailable>' requested here
_LIBCPP_VARIANT_COPY_ASSIGNMENT(
^
/usr/bin/../include/c++/v1/variant:1087:16: note: expanded from macro '_LIBCPP_VARIANT_COPY_ASSIGNMENT'
      : public __move_assignment<__traits<_Types...>> {                        \
               ^
/usr/bin/../include/c++/v1/variant:1120:14: note: in instantiation of template class 'std::__variant_detail::__copy_assignment<std::__variant_detail::__traits<std::monostate, websocketpp::client<websocketpp::config::asio_client>>, std::__variant_detail::_Trait::_Unavailable>' requested here
    : public __copy_assignment<__traits<_Types...>> {
             ^
/usr/bin/../include/c++/v1/variant:1452:39: note: in instantiation of template class 'std::__variant_detail::__impl<std::monostate, websocketpp::client<websocketpp::config::asio_client>>' requested here
  __variant_detail::__impl<_Types...> __impl;
                                      ^
/home/russell/websocketpp/examples/echo_client/echo_client.cpp:37:38: note: in instantiation of template class 'std::variant<std::monostate, websocketpp::client<websocketpp::config::asio_client>>' requested here
std::variant<std::monostate, client> asdf;
                                     ^
1 error generated.
[20/46] Building CXX object examples/telemetry_client/CMakeFiles/telemetry_client.dir/telemetry_client.cpp.o
ninja: build stopped: subcommand failed.
  ```
</details>

This change fixes it. 