### PR TITLE
cmake: make cmake target singleton

### DIFF
--- a/websocketpp-config.cmake.in
+++ b/websocketpp-config.cmake.in
@@ -8,7 +8,7 @@ set_and_check(WEBSOCKETPP_INCLUDE_DIR "@PACKAGE_INSTALL_INCLUDE_DIR@")
 set(WEBSOCKETPP_FOUND TRUE)
 
 #This is a bit of a hack, but it works well. It also allows continued support of CMake 2.8
-if(${CMAKE_VERSION} VERSION_GREATER 3.0.0 OR ${CMAKE_VERSION} VERSION_EQUAL 3.0.0)
+if((${CMAKE_VERSION} VERSION_GREATER 3.0.0 OR ${CMAKE_VERSION} VERSION_EQUAL 3.0.0) AND NOT TARGET websocketpp::websocketpp)
   add_library(websocketpp::websocketpp INTERFACE IMPORTED)
   set_target_properties(websocketpp::websocketpp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${WEBSOCKETPP_INCLUDE_DIR}")
 endif()


### PR DESCRIPTION
Make the target websocketpp::websocketpp a singleton to allow multiple find_package calls in the same CMake project.

Currently it's not possible to use websocketpp in a project with modules and multiple find_package calls.