### PR TITLE
Export symbols

### DIFF
--- a/websocketpp/common/symbol_export.hpp
+++ b/websocketpp/common/symbol_export.hpp
@@ -1,0 +1,39 @@
+#ifndef WEBSOCKETPP_COMMON_SYMBOL_EXPORT_HPP
+#define WEBSOCKETPP_COMMON_SYMBOL_EXPORT_HPP
+
+/**
+ * Defines `_WEBSOCKETPP_SYMBOL_EXPORT`, used to export certain symbols, such
+ * as exception types and `lib::error_category` singletons, that do not work
+ * correctly across shared library boundaries otherwise.
+ */
+
+#if !defined(_WEBSOCKETPP_SYMBOL_EXPORT) && !defined(_WEBSOCKETPP_NO_SYMBOL_EXPORT)
+    // `_WEBSOCKETPP_SYMBOL_EXPORT` can be predefined, or an empty definition
+    // can be forced by defining `_WEBSOCKETPP_NO_SYMBOL_EXPORT`.
+
+    #if defined(_WEBSOCKETPP_BOOST_SYMBOL_EXPORT)
+        // Just use `BOOST_SYMBOL_EXPORT` from Boost.Config .
+
+        #include <boost/config.hpp>
+        #define _WEBSOCKETPP_SYMBOL_EXPORT BOOST_SYMBOL_EXPORT
+
+    // The following is fairly portable, but there are some environments in
+    // which it might not work. If so, predefining `_WEBSOCKETPP_SYMBOL_EXPORT`
+    // or opting out entirely with `_WEBSOCKETPP_NO_SYMBOL_EXPORT` are viable
+    // alternatives.
+    #elif defined(__GNUC__) || defined(__clang__)
+        #if defined(_WIN32) || defined(__CYGWIN__)
+            #define _WEBSOCKETPP_SYMBOL_EXPORT __attribute__((dllexport))
+        #else
+            #define _WEBSOCKETPP_SYMBOL_EXPORT __attribute__((visibility("default")))
+        #endif
+    #elif defined(_WIN32)
+        #define _WEBSOCKETPP_SYMBOL_EXPORT __declspec(dllexport)
+    #endif
+#endif
+
+#ifndef _WEBSOCKETPP_SYMBOL_EXPORT
+    #define _WEBSOCKETPP_SYMBOL_EXPORT
+#endif
+
+#endif

--- a/websocketpp/error.hpp
+++ b/websocketpp/error.hpp
@@ -33,6 +33,7 @@
 #include <utility>
 
 #include <websocketpp/common/cpp11.hpp>
+#include <websocketpp/common/symbol_export.hpp>
 #include <websocketpp/common/system_error.hpp>
 
 namespace websocketpp {
@@ -232,7 +233,7 @@ public:
     }
 };
 
-inline const lib::error_category& get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT const lib::error_category& get_category() {
     static category instance;
     return instance;
 }
@@ -253,7 +254,7 @@ _WEBSOCKETPP_ERROR_CODE_ENUM_NS_END_
 
 namespace websocketpp {
 
-class exception : public std::exception {
+class _WEBSOCKETPP_SYMBOL_EXPORT exception : public std::exception {
 public:
     exception(std::string const & msg, lib::error_code ec = make_error_code(error::general))
       : m_msg(msg.empty() ? ec.message() : msg), m_code(ec)

--- a/websocketpp/extensions/extension.hpp
+++ b/websocketpp/extensions/extension.hpp
@@ -29,6 +29,7 @@
 #define WEBSOCKETPP_EXTENSION_HPP
 
 #include <websocketpp/common/cpp11.hpp>
+#include <websocketpp/common/symbol_export.hpp>
 #include <websocketpp/common/system_error.hpp>
 
 #include <string>
@@ -78,7 +79,7 @@ public:
     }
 };
 
-inline lib::error_category const & get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT lib::error_category const & get_category() {
     static category instance;
     return instance;
 }

--- a/websocketpp/extensions/permessage_deflate/enabled.hpp
+++ b/websocketpp/extensions/permessage_deflate/enabled.hpp
@@ -33,6 +33,7 @@
 #include <websocketpp/common/memory.hpp>
 #include <websocketpp/common/platforms.hpp>
 #include <websocketpp/common/stdint.hpp>
+#include <websocketpp/common/symbol_export.hpp>
 #include <websocketpp/common/system_error.hpp>
 #include <websocketpp/error.hpp>
 
@@ -149,7 +150,7 @@ public:
 };
 
 /// Get a reference to a static copy of the permessage-deflate error category
-inline lib::error_category const & get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT lib::error_category const & get_category() {
     static category instance;
     return instance;
 }

--- a/websocketpp/http/constants.hpp
+++ b/websocketpp/http/constants.hpp
@@ -34,6 +34,7 @@
 #include <vector>
 #include <utility>
 
+#include <websocketpp/common/symbol_export.hpp>
 #include <websocketpp/common/system_error.hpp>
 
 namespace websocketpp {
@@ -297,7 +298,7 @@ inline std::string get_string(value code) {
  * HTTP error message, and a body to return with the HTTP
  * error response.
  */
-class exception : public std::exception {
+class _WEBSOCKETPP_SYMBOL_EXPORT exception : public std::exception {
 public:
     exception(const std::string& log_msg,
                 status_code::value error_code,
@@ -435,7 +436,7 @@ public:
 };
 
 /// Get a reference to a static copy of the asio transport error category
-inline lib::error_category const & get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT lib::error_category const & get_category() {
     static category instance;
     return instance;
 }

--- a/websocketpp/transport/asio/base.hpp
+++ b/websocketpp/transport/asio/base.hpp
@@ -31,6 +31,7 @@
 #include <websocketpp/common/asio.hpp>
 #include <websocketpp/common/cpp11.hpp>
 #include <websocketpp/common/functional.hpp>
+#include <websocketpp/common/symbol_export.hpp>
 #include <websocketpp/common/system_error.hpp>
 #include <websocketpp/common/type_traits.hpp>
 
@@ -208,7 +209,7 @@ public:
 };
 
 /// Get a reference to a static copy of the asio transport error category
-inline lib::error_category const & get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT lib::error_category const & get_category() {
     static category instance;
     return instance;
 }

--- a/websocketpp/transport/base/connection.hpp
+++ b/websocketpp/transport/base/connection.hpp
@@ -31,6 +31,7 @@
 #include <websocketpp/common/cpp11.hpp>
 #include <websocketpp/common/connection_hdl.hpp>
 #include <websocketpp/common/functional.hpp>
+#include <websocketpp/common/symbol_export.hpp>
 #include <websocketpp/common/system_error.hpp>
 
 #include <string>
@@ -216,7 +217,7 @@ class category : public lib::error_category {
     }
 };
 
-inline lib::error_category const & get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT lib::error_category const & get_category() {
     static category instance;
     return instance;
 }

--- a/websocketpp/transport/debug/base.hpp
+++ b/websocketpp/transport/debug/base.hpp
@@ -30,6 +30,7 @@
 
 #include <websocketpp/common/system_error.hpp>
 #include <websocketpp/common/cpp11.hpp>
+#include <websocketpp/common/symbol_export.hpp>
 
 #include <string>
 
@@ -80,7 +81,7 @@ class category : public lib::error_category {
 };
 
 /// Get a reference to a static copy of the debug transport error category
-inline lib::error_category const & get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT lib::error_category const & get_category() {
     static category instance;
     return instance;
 }

--- a/websocketpp/transport/iostream/base.hpp
+++ b/websocketpp/transport/iostream/base.hpp
@@ -32,6 +32,7 @@
 #include <websocketpp/common/cpp11.hpp>
 #include <websocketpp/common/functional.hpp>
 #include <websocketpp/common/connection_hdl.hpp>
+#include <websocketpp/common/symbol_export.hpp>
 
 #include <websocketpp/transport/base/connection.hpp>
 
@@ -109,7 +110,7 @@ class category : public lib::error_category {
 };
 
 /// Get a reference to a static copy of the iostream transport error category
-inline lib::error_category const & get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT lib::error_category const & get_category() {
     static category instance;
     return instance;
 }

--- a/websocketpp/transport/stub/base.hpp
+++ b/websocketpp/transport/stub/base.hpp
@@ -29,6 +29,7 @@
 #define WEBSOCKETPP_TRANSPORT_STUB_BASE_HPP
 
 #include <websocketpp/common/system_error.hpp>
+#include <websocketpp/common/symbol_export.hpp>
 #include <websocketpp/common/cpp11.hpp>
 
 #include <string>
@@ -71,7 +72,7 @@ class category : public lib::error_category {
 };
 
 /// Get a reference to a static copy of the stub transport error category
-inline lib::error_category const & get_category() {
+inline _WEBSOCKETPP_SYMBOL_EXPORT lib::error_category const & get_category() {
     static category instance;
     return instance;
 }


### PR DESCRIPTION
Symbol conflicts can occur when **WebSocket++** headers are included in multiple shared libraries. The various `lib::error_category` singletons are particularly troublesome in this regard. For example:

I recently ran into a bug in my code that was traceable to a comparison of error codes in `websocketpp::transport::asio::connection::handle_post_init_timeout()`.

```
void handle_post_init_timeout(timer_ptr, init_handler callback,
    lib::error_code const & ec)
{
    lib::error_code ret_ec;

    if (ec) {
        if (ec == transport::error::operation_aborted) {
            m_alog->write(log::alevel::devel,
                "asio post init timer cancelled");
            return;
        }
    // ...
}
```

`ec == transport::error::operation_aborted` invokes `lib::error_code::operator==`, which first checks if the two operands' error categories are equal. In my case, they should have been, but the `websocketpp::transport::error::category` singleton was included in two shared libraries, one of them having symbol visibility set to "hidden" by default. As the singleton symbol was not specifically exported from this library, it wasn't visible to the other library, and thus was not linked properly. This resulted in the address of one library's instance of the singleton being different than that of the other library's, and in the equality comparison returning the wrong result.

In this pull request, I have explicitly exported `lib::error_category` singletons as well as exception classes (see *Problems with C++ exceptions* [here](https://gcc.gnu.org/wiki/Visibility)) via the new `_WEBSOCKETPP_EXPORT_SYMBOL` macro.

My changes were made with WebSocket++'s focus on portability and minimizing dependencies in mind, but there may still be some concerns. I believe the decreased risk of symbol conflicts is worth it, but it is up to the maintainers in the end.

I ran the provided tests on my machine (Ubuntu 22.04, using GCC 12), and all went well. I additionally verified that the correct symbols were exported.