### PR TITLE
Update uri.hpp

### DIFF
--- a/websocketpp/uri.hpp
+++ b/websocketpp/uri.hpp
@@ -245,9 +245,7 @@ public:
         if (m_port == (m_secure ? uri_default_secure_port : uri_default_port)) {
             return m_host;
         } else {
-            std::stringstream p;
-            p << m_host << ":" << m_port;
-            return p.str();
+            return std::to_string(m_port);
         }
     }
 


### PR DESCRIPTION
std::string get_port_str() const {
        std::stringstream p;
        p << m_port;
        return p.str();
    }

if m_port == 9999, sometimes p.str() returns "**9,999**",i don't know why. but change to use std::to_string(), it will be ok.