### PR TITLE
Remove template-id warnings when compiling in C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
     set (Boost_USE_MULTITHREADED TRUE)
     set (Boost_ADDITIONAL_VERSIONS "1.39.0" "1.40.0" "1.41.0" "1.42.0" "1.43.0" "1.44.0" "1.46.1") # todo: someone who knows better spesify these!
 
-    find_package (Boost 1.39.0 COMPONENTS "${WEBSOCKETPP_BOOST_LIBS}")
+    find_package (Boost 1.39.0 COMPONENTS ${WEBSOCKETPP_BOOST_LIBS})
 
     if (Boost_FOUND)
         # Boost is a project wide global dependency.

--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -109,7 +109,11 @@ public:
 
 
     /// Destructor
-    ~endpoint<connection,config>() {}
+    #if __cplusplus >= 202002L
+        ~endpoint() {}
+    #else
+        ~endpoint<connection,config>() {}
+    #endif
 
     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
         // no copy constructor because endpoints are not copyable

--- a/websocketpp/logger/basic.hpp
+++ b/websocketpp/logger/basic.hpp
@@ -58,38 +58,80 @@ namespace log {
 template <typename concurrency, typename names>
 class basic {
 public:
+#if __cplusplus >= 202002L
+    basic(channel_type_hint::value h =
+        channel_type_hint::access)
+      : m_static_channels(0xffffffff)
+      , m_dynamic_channels(0)
+      , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+#else
     basic<concurrency,names>(channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+#endif
 
+#if __cplusplus >= 202002L
+    basic(std::ostream * out)
+      : m_static_channels(0xffffffff)
+      , m_dynamic_channels(0)
+      , m_out(out) {}
+#else
     basic<concurrency,names>(std::ostream * out)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(out) {}
+#endif
 
+#if __cplusplus >= 202002L
+    basic(level c, channel_type_hint::value h =
+        channel_type_hint::access)
+      : m_static_channels(c)
+      , m_dynamic_channels(0)
+      , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+#else
     basic<concurrency,names>(level c, channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+#endif
 
+#if __cplusplus >= 202002L
+    basic(level c, std::ostream * out)
+      : m_static_channels(c)
+      , m_dynamic_channels(0)
+      , m_out(out) {}
+#else
     basic<concurrency,names>(level c, std::ostream * out)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(out) {}
+#endif
 
     /// Destructor
+#if __cplusplus >= 202002L
+    ~basic() {}
+#else
     ~basic<concurrency,names>() {}
+#endif
 
     /// Copy constructor
+#if __cplusplus >= 202002L
+    basic(basic const & other)
+     : m_static_channels(other.m_static_channels)
+     , m_dynamic_channels(other.m_dynamic_channels)
+     , m_out(other.m_out)
+    {}
+#else
     basic<concurrency,names>(basic<concurrency,names> const & other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)
     {}
-    
+#endif
+
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no copy assignment operator because of const member variables
     basic<concurrency,names> & operator=(basic<concurrency,names> const &) = delete;
@@ -97,11 +139,19 @@ public:
 
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
     /// Move constructor
+#if __cplusplus >= 202002L
+    basic(basic && other)
+     : m_static_channels(other.m_static_channels)
+     , m_dynamic_channels(other.m_dynamic_channels)
+     , m_out(other.m_out)
+    {}
+#else
     basic<concurrency,names>(basic<concurrency,names> && other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)
     {}
+#endif
 
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no move assignment operator because of const member variables

--- a/websocketpp/logger/syslog.hpp
+++ b/websocketpp/logger/syslog.hpp
@@ -46,24 +46,34 @@ template <typename concurrency, typename names>
 class syslog : public basic<concurrency, names> {
 public:
     typedef basic<concurrency, names> base;
-
     /// Construct the logger
     /**
      * @param hint A channel type specific hint for how to construct the logger
      */
+#if __cplusplus >= 202002L
+    syslog(channel_type_hint::value hint =
+        channel_type_hint::access)
+      : basic<concurrency,names>(hint), m_channel_type_hint(hint) {}
+#else
     syslog<concurrency,names>(channel_type_hint::value hint =
         channel_type_hint::access)
       : basic<concurrency,names>(hint), m_channel_type_hint(hint) {}
+#endif
 
     /// Construct the logger
     /**
      * @param channels A set of channels to statically enable
      * @param hint A channel type specific hint for how to construct the logger
      */
+#if __cplusplus >= 202002L
+    syslog(level channels, channel_type_hint::value hint =
+        channel_type_hint::access)
+      : basic<concurrency,names>(channels, hint), m_channel_type_hint(hint) {}
+#else
     syslog<concurrency,names>(level channels, channel_type_hint::value hint =
         channel_type_hint::access)
       : basic<concurrency,names>(channels, hint), m_channel_type_hint(hint) {}
-
+#endif
     /// Write a string message to the given channel
     /**
      * @param channel The channel to write to

--- a/websocketpp/roles/server_endpoint.hpp
+++ b/websocketpp/roles/server_endpoint.hpp
@@ -71,24 +71,44 @@ public:
         endpoint_type::m_alog->write(log::alevel::devel, "server constructor");
     }
 
-    /// Destructor
+/// Destructor
+#if __cplusplus >= 202002L
+    ~server() {}
+#else
     ~server<config>() {}
+#endif
 
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no copy constructor because endpoints are not copyable
+#if __cplusplus >= 202002L
+    server(server &) = delete;
+#else
     server<config>(server<config> &) = delete;
+#endif
 
     // no copy assignment operator because endpoints are not copyable
+#if __cplusplus >= 202002L
+    server & operator=(server const &) = delete;
+#else
     server<config> & operator=(server<config> const &) = delete;
+#endif
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
     /// Move constructor
+#if __cplusplus >= 202002L
+    server(server && o) : endpoint<connection<config>,config>(std::move(o)) {}
+#else
     server<config>(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
+#endif
 
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no move assignment operator because of const member variables
+#if __cplusplus >= 202002L
+    server & operator=(server &&) = delete;
+#else
     server<config> & operator=(server<config> &&) = delete;
+#endif
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #endif // _WEBSOCKETPP_MOVE_SEMANTICS_


### PR DESCRIPTION
This PR fixes all template-id warnings when trying to compile the project in C++20 mode. Original code is still used when compiling with older standards.