### PR TITLE
Update minimum required CMake version to comply with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 ############ Setup project and cmake
 # Minimum cmake requirement. We should require a quite recent
 # cmake for the dependency find macros etc. to be up to date.
-cmake_minimum_required (VERSION 2.8.8)
+cmake_minimum_required (VERSION 3.10)
 
 ############ Paths
 


### PR DESCRIPTION
CMake now forbids minimum CMake versions below version 3.5 and provides deprecated warnings for anything below 3.10.  This PR updates the version to 3.10 to (a) make the project configure/generate again and bumps it directly to 3.10 to prevent the deprecation warning, too