### PR TITLE
Update endpoint.hpp

### DIFF
--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -109,7 +109,7 @@ public:
 
 
     /// Destructor
-    ~endpoint<connection,config>() {}
+    ~endpoint() {} //for CPP 20
 
     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
         // no copy constructor because endpoints are not copyable


### PR DESCRIPTION
C++20 disallows explicitly writing template-ids (e.g. basic<...>()) for constructors and destructors.