### PR TITLE
Fix/cpp23 aligned storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 ############ Setup project and cmake
 # Minimum cmake requirement. We should require a quite recent
 # cmake for the dependency find macros etc. to be up to date.
-cmake_minimum_required (VERSION 3.30)
+cmake_minimum_required (VERSION 2.8.8)
 
 ############ Paths
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 ############ Setup project and cmake
 # Minimum cmake requirement. We should require a quite recent
 # cmake for the dependency find macros etc. to be up to date.
-cmake_minimum_required (VERSION 2.8.8)
+cmake_minimum_required (VERSION 3.30)
 
 ############ Paths
 

--- a/websocketpp/common/type_traits.hpp
+++ b/websocketpp/common/type_traits.hpp
@@ -28,6 +28,7 @@
 #ifndef WEBSOCKETPP_COMMON_TYPE_TRAITS_HPP
 #define WEBSOCKETPP_COMMON_TYPE_TRAITS_HPP
 
+#include <cstddef>
 #include <websocketpp/common/cpp11.hpp>
 
 // If we've determined that we're in full C++11 mode and the user hasn't
@@ -52,7 +53,16 @@ namespace websocketpp {
 namespace lib {
 
 #ifdef _WEBSOCKETPP_CPP11_TYPE_TRAITS_
-    using std::aligned_storage;
+    template<std::size_t N>
+    struct aligned_storage {
+#if __cplusplus >= 202300L
+        struct type {
+            alignas(std::max_align_t) unsigned char data[N];
+        };
+#else
+        using type = typename std::aligned_storage<N>::type;
+#endif
+    };
     using std::is_same;
 #else
     using boost::aligned_storage;

--- a/websocketpp/common/type_traits.hpp
+++ b/websocketpp/common/type_traits.hpp
@@ -53,6 +53,8 @@ namespace websocketpp {
 namespace lib {
 
 #ifdef _WEBSOCKETPP_CPP11_TYPE_TRAITS_
+    // NOTE: this is may not be the best way to detect c++23 compilers, but it worked fine for all test I did
+    // std::aligned_storage has been depracated as of c++23 (see P1413R3 for more details)
     template<std::size_t N>
     struct aligned_storage {
 #if __cplusplus >= 202300L


### PR DESCRIPTION
Small compatibility patch for C++23 compilers since from C++23 onwards std::aligned_storage was deprecated. For more information see [P1413R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1413r3.pdf).