### PR TITLE
fix boost_1.89

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
 
     # Visual studio
     if (MSVC)
-        set (WEBSOCKETPP_BOOST_LIBS system thread)
+        set (WEBSOCKETPP_BOOST_LIBS thread)
         set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL /Gy /GF /Ox /Ob2 /Ot /Oi /MP /arch:SSE2 /fp:fast")
         set (CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG /INCREMENTAL:NO /OPT:REF /OPT:ICF")
         add_definitions (/W3 /wd4996 /wd4995 /wd4355)
@@ -129,7 +129,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
             set (WEBSOCKETPP_PLATFORM_LIBS pthread)
         endif()
         set (WEBSOCKETPP_PLATFORM_TLS_LIBS ssl crypto)
-        set (WEBSOCKETPP_BOOST_LIBS system thread)
+        set (WEBSOCKETPP_BOOST_LIBS thread)
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
         if (NOT APPLE)
             add_definitions (-DNDEBUG -Wall -Wcast-align) # todo: should we use CMAKE_C_FLAGS for these?
@@ -139,7 +139,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
         execute_process (COMMAND ${CMAKE_CXX_COMPILER} "-dumpversion" OUTPUT_VARIABLE GCC_VERSION)
         if ("${GCC_VERSION}" STRGREATER "4.4.0")
             message("* C++11 support partially enabled due to GCC version ${GCC_VERSION}")
-            set (WEBSOCKETPP_BOOST_LIBS system thread)
+            set (WEBSOCKETPP_BOOST_LIBS thread)
         endif ()
     endif ()
 
@@ -151,7 +151,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
             set (WEBSOCKETPP_PLATFORM_LIBS pthread)
         endif()
         set (WEBSOCKETPP_PLATFORM_TLS_LIBS ssl crypto)
-        set (WEBSOCKETPP_BOOST_LIBS system thread)
+        set (WEBSOCKETPP_BOOST_LIBS thread)
         set (CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++0x -stdlib=libc++") # todo: is libc++ really needed here?
         if (NOT APPLE)
             add_definitions (-DNDEBUG -Wall -Wno-padded) # todo: should we use CMAKE_C_FLAGS for these?
@@ -213,9 +213,8 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
     set (Boost_FIND_QUIETLY TRUE)
     set (Boost_DEBUG FALSE)
     set (Boost_USE_MULTITHREADED TRUE)
-    set (Boost_ADDITIONAL_VERSIONS "1.39.0" "1.40.0" "1.41.0" "1.42.0" "1.43.0" "1.44.0" "1.46.1") # todo: someone who knows better spesify these!
 
-    find_package (Boost 1.39.0 COMPONENTS "${WEBSOCKETPP_BOOST_LIBS}")
+    find_package (Boost 1.70.0 CONFIG COMPONENTS ${WEBSOCKETPP_BOOST_LIBS})
 
     if (Boost_FOUND)
         # Boost is a project wide global dependency.


### PR DESCRIPTION
boost_system is header-only since 1.69 and the stub library is removed since boost-1.89.
call 'Boost CONFIG' using the .cmake provided by upstream.