### PR TITLE
Permessage deflate max message size

### DIFF
--- a/test/extension/permessage_deflate.cpp
+++ b/test/extension/permessage_deflate.cpp
@@ -39,7 +39,10 @@
 #include <websocketpp/utilities.hpp>
 #include <iostream>
 
-class config {};
+class config {
+public:
+    static const size_t max_message_size = 16u * 1024u * 1024u;
+};
 
 typedef websocketpp::extensions::permessage_deflate::enabled<config> enabled_type;
 typedef websocketpp::extensions::permessage_deflate::disabled<config> disabled_type;
@@ -749,4 +752,56 @@ BOOST_AUTO_TEST_CASE( decompress_data ) {
 
     BOOST_CHECK_EQUAL( v.ec, websocketpp::lib::error_code() );
     BOOST_CHECK_EQUAL( out, reference );
+}
+
+BOOST_AUTO_TEST_CASE( decompress_data_at_size_limit ) {
+    ext_vars v;
+    size_t const limit = config::max_message_size;
+
+    std::string compress_in(limit, '*');
+    std::string compress_out;
+    std::string decompress_out;
+
+    v.ec = v.exts.init(true);
+    BOOST_CHECK_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.exts.compress(compress_in,compress_out);
+    BOOST_CHECK_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.exts.decompress(
+        reinterpret_cast<const uint8_t *>(compress_out.data()),
+        compress_out.size(),
+        decompress_out
+    );
+
+    BOOST_CHECK_EQUAL( v.ec, websocketpp::lib::error_code() );
+    BOOST_CHECK_EQUAL( decompress_out.size(), limit );
+    BOOST_CHECK_EQUAL( decompress_out, compress_in );
+}
+
+BOOST_AUTO_TEST_CASE( decompress_data_over_size_limit ) {
+    ext_vars v;
+    size_t const limit = config::max_message_size;
+
+    std::string compress_in(limit + 1, '*');
+    std::string compress_out;
+    std::string decompress_out;
+
+    v.ec = v.exts.init(true);
+    BOOST_CHECK_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.exts.compress(compress_in,compress_out);
+    BOOST_CHECK_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.exts.decompress(
+        reinterpret_cast<const uint8_t *>(compress_out.data()),
+        compress_out.size(),
+        decompress_out
+    );
+
+    BOOST_CHECK( v.ec );
+    BOOST_REQUIRE_EQUAL( decompress_out.size(), limit );
+    BOOST_CHECK_EQUAL( decompress_out[0], '*' );
+    BOOST_CHECK_EQUAL( decompress_out[limit - 1], '*' );
+    BOOST_CHECK_EQUAL( decompress_out.find_first_not_of('*'), std::string::npos );
 }

--- a/test/processors/hybi13.cpp
+++ b/test/processors/hybi13.cpp
@@ -30,6 +30,7 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include <websocketpp/processors/hybi13.hpp>
 
@@ -55,6 +56,7 @@ struct stub_config {
 
     struct permessage_deflate_config {
         typedef stub_config::request_type request_type;
+        static const size_t max_message_size = 16000000;
     };
 
     typedef websocketpp::extensions::permessage_deflate::disabled
@@ -77,6 +79,7 @@ struct stub_config_ext {
 
     struct permessage_deflate_config {
         typedef stub_config_ext::request_type request_type;
+        static const size_t max_message_size = 16000000;
     };
 
     typedef websocketpp::extensions::permessage_deflate::enabled
@@ -536,6 +539,48 @@ BOOST_AUTO_TEST_CASE( multiple_frame_message_too_large ) {
     // read second message frame that puts the size over the limit
     BOOST_CHECK_EQUAL( env.p.consume(frame1,9,env.ec), 6 );
     BOOST_CHECK_EQUAL( env.ec, websocketpp::processor::error::message_too_big );
+}
+
+BOOST_AUTO_TEST_CASE( compressed_frame_message_too_large ) {
+    processor_setup_ext client(false);
+    processor_setup_ext server(true);
+    size_t const limit = stub_config_ext::max_message_size;
+
+    std::pair<websocketpp::lib::error_code,std::string> neg_results;
+
+    server.req.replace_header(
+        "Sec-WebSocket-Extensions",
+        "permessage-deflate; client_max_window_bits"
+    );
+
+    neg_results = server.p.negotiate_extensions(server.req);
+    BOOST_REQUIRE( !neg_results.first );
+
+    client.res.replace_header("Sec-WebSocket-Extensions",neg_results.second);
+    neg_results = client.p.negotiate_extensions(client.res);
+    BOOST_REQUIRE( !neg_results.first );
+
+    message_ptr in = client.msg_manager->get_message();
+    message_ptr out = client.msg_manager->get_message();
+
+    BOOST_REQUIRE( in );
+    BOOST_REQUIRE( out );
+
+    in->set_opcode(websocketpp::frame::opcode::BINARY);
+    in->set_payload(std::string(limit + 1, '*'));
+    in->set_compressed(true);
+
+    client.ec = client.p.prepare_data_frame(in,out);
+    BOOST_REQUIRE_EQUAL( client.ec, websocketpp::lib::error_code() );
+
+    std::string frame = out->get_header();
+    frame += out->get_payload();
+    std::vector<uint8_t> frame_bytes(frame.begin(),frame.end());
+
+    BOOST_CHECK_GT( server.p.consume(&frame_bytes[0],frame_bytes.size(),server.ec), 0 );
+    BOOST_CHECK_EQUAL( server.ec, websocketpp::processor::error::message_too_big );
+    BOOST_CHECK_EQUAL( server.p.ready(), false );
+    BOOST_CHECK_EQUAL( server.p.get_message(), message_ptr() );
 }
 
 

--- a/websocketpp/config/core.hpp
+++ b/websocketpp/config/core.hpp
@@ -259,6 +259,7 @@ struct core {
     /// permessage_compress extension
     struct permessage_deflate_config {
         typedef core::request_type request_type;
+        static const size_t max_message_size = 32000000;
 
         /// If the remote endpoint requests that we reset the compression
         /// context after each message should we honor the request?

--- a/websocketpp/config/core_client.hpp
+++ b/websocketpp/config/core_client.hpp
@@ -256,6 +256,7 @@ struct core_client {
     /// permessage_deflate extension
     struct permessage_deflate_config {
         typedef core_client::request_type request_type;
+        static const size_t max_message_size = 32000000;
 
         /// If the remote endpoint requests that we reset the compression
         /// context after each message should we honor the request?

--- a/websocketpp/config/debug.hpp
+++ b/websocketpp/config/debug.hpp
@@ -248,6 +248,7 @@ struct debug_core {
     /// permessage_compress extension
     struct permessage_deflate_config {
         typedef type::request_type request_type;
+        static const size_t max_message_size = 32000000;
 
         /// If the remote endpoint requests that we reset the compression
         /// context after each message should we honor the request?

--- a/websocketpp/config/minimal_server.hpp
+++ b/websocketpp/config/minimal_server.hpp
@@ -274,6 +274,7 @@ struct minimal_server {
     /// permessage_compress extension
     struct permessage_deflate_config {
         typedef core::request_type request_type;
+        static const size_t max_message_size = 32000000;
 
         /// If the remote endpoint requests that we reset the compression
         /// context after each message should we honor the request?

--- a/websocketpp/extensions/permessage_deflate/disabled.hpp
+++ b/websocketpp/extensions/permessage_deflate/disabled.hpp
@@ -63,7 +63,12 @@ public:
      * @return Status code and value to return to remote endpoint
      */
     err_str_pair negotiate(http::attribute_list const &) {
-        return make_pair(make_error_code(error::disabled),std::string());
+        return make_pair(
+            websocketpp::extensions::error::make_error_code(
+                websocketpp::extensions::error::disabled
+            ),
+            std::string()
+        );
     }
 
     /// Initialize state
@@ -100,6 +105,8 @@ public:
         return "";
     }
 
+    void set_max_message_size(size_t) {}
+
     /// Compress bytes
     /**
      * @param [in] in String to compress
@@ -107,7 +114,9 @@ public:
      * @return Error or status code
      */
     lib::error_code compress(std::string const &, std::string &) {
-        return make_error_code(error::disabled);
+        return websocketpp::extensions::error::make_error_code(
+            websocketpp::extensions::error::disabled
+        );
     }
 
     /// Decompress bytes
@@ -118,7 +127,13 @@ public:
      * @return Error or status code
      */
     lib::error_code decompress(uint8_t const *, size_t, std::string &) {
-        return make_error_code(error::disabled);
+        return websocketpp::extensions::error::make_error_code(
+            websocketpp::extensions::error::disabled
+        );
+    }
+
+    static bool is_message_too_big(lib::error_code const &) {
+        return false;
     }
 };
 

--- a/websocketpp/extensions/permessage_deflate/enabled.hpp
+++ b/websocketpp/extensions/permessage_deflate/enabled.hpp
@@ -108,6 +108,9 @@ enum value {
     /// Invalid value for max_window_bits
     invalid_max_window_bits,
 
+    /// Decompressed message exceeded the hard size limit
+    message_too_big,
+
     /// ZLib Error
     zlib_error,
 
@@ -138,6 +141,8 @@ public:
                 return "Unsupported extension attributes";
             case invalid_max_window_bits:
                 return "Invalid value for max_window_bits";
+            case message_too_big:
+                return "Message too big";
             case zlib_error:
                 return "A zlib function returned an error";
             case uninitialized:
@@ -227,6 +232,7 @@ public:
       , m_client_max_window_bits_mode(mode::accept)
       , m_initialized(false)
       , m_compress_buffer_size(8192)
+      , m_max_message_size(config::max_message_size)
     {
         m_dstate.zalloc = Z_NULL;
         m_dstate.zfree = Z_NULL;
@@ -485,6 +491,10 @@ public:
         return "permessage-deflate; client_no_context_takeover; client_max_window_bits";
     }
 
+    void set_max_message_size(size_t value) {
+        m_max_message_size = value;
+    }
+
     /// Validate extension response
     /**
      * Confirm that the server has negotiated settings compatible with our
@@ -596,7 +606,14 @@ public:
         m_istate.next_in = const_cast<unsigned char *>(buf);
 
         do {
-            m_istate.avail_out = m_compress_buffer_size;
+            size_t const remaining = out.size() < m_max_message_size
+                ? m_max_message_size - out.size()
+                : 0;
+            // Keep one extra byte of scratch space so we can detect overflow
+            // before appending past the configured per-message limit.
+            size_t const output_limit = (std::min)(m_compress_buffer_size, remaining + size_t(1));
+
+            m_istate.avail_out = static_cast<uInt>(output_limit);
             m_istate.next_out = m_decompress_buffer.get();
 
             ret = inflate(&m_istate, Z_SYNC_FLUSH);
@@ -605,14 +622,32 @@ public:
                 return make_error_code(error::zlib_error);
             }
 
+            size_t const output = output_limit - static_cast<size_t>(m_istate.avail_out);
+
+            if (output > remaining) {
+                if (remaining > 0) {
+                    out.append(
+                        reinterpret_cast<char *>(m_decompress_buffer.get()),
+                        remaining
+                    );
+                }
+
+                return make_error_code(error::message_too_big);
+            }
+
             out.append(
                 reinterpret_cast<char *>(m_decompress_buffer.get()),
-                m_compress_buffer_size - m_istate.avail_out
+                output
             );
         } while (m_istate.avail_out == 0);
 
         return lib::error_code();
     }
+
+    static bool is_message_too_big(lib::error_code const & ec) {
+        return ec == make_error_code(error::message_too_big);
+    }
+
 private:
     /// Generate negotiation response
     /**
@@ -804,6 +839,7 @@ private:
     bool m_initialized;
     int m_flush;
     size_t m_compress_buffer_size;
+    size_t m_max_message_size;
     lib::unique_ptr_uchar_array m_compress_buffer;
     lib::unique_ptr_uchar_array m_decompress_buffer;
     z_stream m_dstate;

--- a/websocketpp/processors/base.hpp
+++ b/websocketpp/processors/base.hpp
@@ -175,7 +175,7 @@ public:
             case error::protocol_violation:
                 return "Generic protocol violation";
             case error::message_too_big:
-                return "A message was too large";
+                return "Message too big";
             case error::invalid_payload:
                 return "A payload contained invalid data";
             case error::invalid_arguments:

--- a/websocketpp/processors/hybi13.hpp
+++ b/websocketpp/processors/hybi13.hpp
@@ -74,6 +74,7 @@ public:
       , m_msg_manager(manager)
       , m_rng(rng)
     {
+        m_permessage_deflate.set_max_message_size(base::m_max_message_size);
         reset_headers();
     }
 
@@ -529,6 +530,10 @@ public:
             lib::error_code ec;
             ec = m_permessage_deflate.decompress(trailer,4,out);
             if (ec) {
+                if (permessage_deflate_type::is_message_too_big(ec))
+                {
+                    return make_error_code(error::message_too_big);
+                }
                 return ec;
             }
         }
@@ -557,6 +562,10 @@ public:
             frame::MAX_EXTENDED_HEADER_LENGTH,
             static_cast<uint8_t>(0x00)
         );
+    }
+
+    void handle_max_message_size_changed(size_t new_value) {
+        m_permessage_deflate.set_max_message_size(new_value);
     }
 
     /// Test whether or not the processor has a message ready
@@ -815,6 +824,10 @@ protected:
             // Decompress current buffer into the message buffer
             ec = m_permessage_deflate.decompress(buf,len,out);
             if (ec) {
+                if (permessage_deflate_type::is_message_too_big(ec))
+                {
+                    ec = make_error_code(error::message_too_big);
+                }
                 return 0;
             }
         } else {

--- a/websocketpp/processors/processor.hpp
+++ b/websocketpp/processors/processor.hpp
@@ -202,6 +202,7 @@ public:
      */
     void set_max_message_size(size_t new_value) {
         m_max_message_size = new_value;
+        this->handle_max_message_size_changed(new_value);
     }
 
     /// Returns whether or not the permessage_compress extension is implemented
@@ -212,6 +213,11 @@ public:
     virtual bool has_permessage_compress() const {
         return false;
     }
+
+protected:
+    virtual void handle_max_message_size_changed(size_t) {}
+
+public:
 
     /// Initializes extensions based on the Sec-WebSocket-Extensions header
     /**


### PR DESCRIPTION
## Problem (#1191)

`permessage-deflate` can currently inflate compressed payloads without enforcing websocketpp's existing configurable `max_message_size` during decompression. As a result, a compressed frame can expand past the configured per-message budget before control returns to application or processor logic.

This differs from the handling of uncompressed messages, where `max_message_size` is treated as a strict upper bound.

---

## Overview of changes

This branch contains two commits:

1. `0355e50` — `test: add permessage-deflate size limit regressions`
2. `71327e7` — `permessage-deflate: enforce max_message_size during decompression`

The fix commit implements the following:

- introduces a permessage-deflate `message_too_big` error condition,
- enforces the existing configurable `max_message_size` during decompression,
- propagates processor `set_max_message_size()` into the permessage-deflate extension,
- maps the extension error to `processor::error::message_too_big` in `hybi13.hpp`.

The implementation bounds inflation using the remaining output budget, detecting overflow before appending data beyond the configured limit.

---

## Tests

Added coverage:

- `test/extension/permessage_deflate.cpp`
  - exact-boundary success at a configured 16 MiB limit
  - over-limit failure at configured limit + 1
- `test/processors/hybi13.cpp`
  - oversized compressed frame maps to `processor::error::message_too_big`
  - test-only commit remains baseline-compilable

---

## Validation

Reviewer flow:

1. check out `0355e50` and run the new tests (expected to fail)
2. apply `71327e7` and rerun (expected to pass)

Observed results:

- prior to the fix:
  - extension tests allow decompression past the configured limit without error
  - processor tests do not surface `message_too_big` for oversized decompressed messages
- with the fix applied:
  - targeted extension regressions pass
  - processor test suite passes

---

## Reviewer notes

- The fix reuses websocketpp's existing `max_message_size` configuration rather than introducing a new policy value.
- Processor handling reuses the existing `message_too_big` path rather than adding a separate close or error mechanism.

---

## Files touched

- `test/extension/permessage_deflate.cpp`
- `test/processors/hybi13.cpp`
- `websocketpp/config/core.hpp`
- `websocketpp/config/core_client.hpp`
- `websocketpp/config/debug.hpp`
- `websocketpp/config/minimal_server.hpp`
- `websocketpp/extensions/permessage_deflate/disabled.hpp`
- `websocketpp/extensions/permessage_deflate/enabled.hpp`
- `websocketpp/processors/processor.hpp`
- `websocketpp/processors/hybi13.hpp`

---

## Target branch

Per repository guidance in `readme.md`, this series is based on and intended for `develop`.
