### PR TITLE
Honor client_no_context_takeover offer

### DIFF
--- a/test/extension/permessage_deflate.cpp
+++ b/test/extension/permessage_deflate.cpp
@@ -54,6 +54,18 @@ struct ext_vars {
 namespace pmde = websocketpp::extensions::permessage_deflate::error;
 namespace pmd_mode = websocketpp::extensions::permessage_deflate::mode;
 
+static std::string make_deterministic_message(size_t size) {
+    std::string message(size, '\0');
+    unsigned int state = 0x12345678u;
+
+    for (size_t i = 0; i < size; ++i) {
+        state = state * 1664525u + 1013904223u;
+        message[i] = static_cast<char>(state >> 24);
+    }
+
+    return message;
+}
+
 // Ensure the disabled extension behaves appropriately disabled
 
 BOOST_AUTO_TEST_CASE( disabled_is_disabled ) {
@@ -701,6 +713,57 @@ BOOST_AUTO_TEST_CASE( compress_data_no_context_takeover ) {
     BOOST_CHECK_EQUAL( compress_in, decompress_out );
 
     BOOST_CHECK_EQUAL( compress_out1, compress_out2 );
+}
+
+BOOST_AUTO_TEST_CASE( compress_data_client_no_context_takeover_offer_without_response_param ) {
+    ext_vars v;
+    enabled_type second_message_server;
+
+    std::string offer = v.extc.generate_offer();
+    std::string compress_in = make_deterministic_message(4096);
+    std::string compress_out1;
+    std::string compress_out2;
+    std::string decompress_out1;
+    std::string decompress_out2;
+    websocketpp::http::attribute_list response_without_client_no_context_takeover;
+
+    BOOST_CHECK( offer.find("client_no_context_takeover") != std::string::npos );
+
+    v.ec = v.extc.validate_offer(response_without_client_no_context_takeover);
+    BOOST_REQUIRE_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.extc.init(false);
+    BOOST_REQUIRE_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.exts.init(true);
+    BOOST_REQUIRE_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = second_message_server.init(true);
+    BOOST_REQUIRE_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.extc.compress(compress_in,compress_out1);
+    BOOST_REQUIRE_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.extc.compress(compress_in,compress_out2);
+    BOOST_REQUIRE_EQUAL( v.ec, websocketpp::lib::error_code() );
+
+    v.ec = v.exts.decompress(
+        reinterpret_cast<const uint8_t *>(compress_out1.data()),
+        compress_out1.size(),
+        decompress_out1
+    );
+    BOOST_REQUIRE_EQUAL( v.ec, websocketpp::lib::error_code() );
+    BOOST_CHECK( decompress_out1 == compress_in );
+
+    v.ec = second_message_server.decompress(
+        reinterpret_cast<const uint8_t *>(compress_out2.data()),
+        compress_out2.size(),
+        decompress_out2
+    );
+    BOOST_CHECK_EQUAL( v.ec, websocketpp::lib::error_code() );
+    if (!v.ec) {
+        BOOST_CHECK( decompress_out2 == compress_in );
+    }
 }
 
 BOOST_AUTO_TEST_CASE( compress_empty ) {

--- a/websocketpp/extensions/permessage_deflate/enabled.hpp
+++ b/websocketpp/extensions/permessage_deflate/enabled.hpp
@@ -221,6 +221,7 @@ public:
       : m_enabled(false)
       , m_server_no_context_takeover(false)
       , m_client_no_context_takeover(false)
+      , m_client_no_context_takeover_offered(false)
       , m_server_max_window_bits(15)
       , m_client_max_window_bits(15)
       , m_server_max_window_bits_mode(mode::accept)
@@ -307,7 +308,8 @@ public:
         m_compress_buffer.reset(new unsigned char[m_compress_buffer_size]);
         m_decompress_buffer.reset(new unsigned char[m_compress_buffer_size]);
         if ((m_server_no_context_takeover && is_server) ||
-            (m_client_no_context_takeover && !is_server))
+            ((m_client_no_context_takeover ||
+              m_client_no_context_takeover_offered) && !is_server))
         {
             m_flush = Z_FULL_FLUSH;
         } else {
@@ -481,6 +483,7 @@ public:
      * @return A WebSocket extension offer string for this extension
      */
     std::string generate_offer() const {
+        m_client_no_context_takeover_offered = true;
         // TODO: this should be dynamically generated based on user settings
         return "permessage-deflate; client_no_context_takeover; client_max_window_bits";
     }
@@ -796,6 +799,7 @@ private:
     bool m_enabled;
     bool m_server_no_context_takeover;
     bool m_client_no_context_takeover;
+    mutable bool m_client_no_context_takeover_offered;
     uint8_t m_server_max_window_bits;
     uint8_t m_client_max_window_bits;
     mode::value m_server_max_window_bits_mode;


### PR DESCRIPTION
## Problem (#1193)

In the default WebSocket++ `permessage-deflate` client configuration, the client offer generated by `generate_offer()` advertises `client_no_context_takeover`, but client-side compression behavior only honors that setting when the server echoes the parameter in its response. If the server accepts `permessage-deflate` and omits `client_no_context_takeover`, the client still reuses compressor context across messages.

This means the offer string and the actual outbound behavior can diverge.

---

## Branch and commit series

- Branch: `permessage-deflate-client-no-context-takeover`
- Base: `origin/develop`

This branch contains two commits:

1. `b8e4b6f` — `Add client_no_context_takeover regression test`
2. `6ed4712` — `Honor client_no_context_takeover offer`

---

## Overview of changes

The fix keeps track of whether the client advertised `client_no_context_takeover` in `generate_offer()` and carries that offer-side state into the client `init(false)` path.

With that state available at initialization time, the client uses no-context-takeover compression behavior for outbound messages even when the server omits `client_no_context_takeover` from the negotiated response parameters.

---

## Tests

Added coverage in `test/extension/permessage_deflate.cpp` for the case where:

- the client offer includes `client_no_context_takeover`
- the server response attribute list is empty
- the client compresses the same deterministic message twice
- each compressed output is decompressed independently by a fresh server-side extension instance

---

## Validation

Reviewer flow:

1. check out `b8e4b6f` and run the new regression (expected to fail)
2. apply `6ed4712` and rerun (expected to pass)

Observed behavior:

- before the fix, the second compressed message depends on prior context and fails the fresh-receiver model
- with the fix, both messages decompress successfully and match the original input

---

## Files touched

- `test/extension/permessage_deflate.cpp`
- `websocketpp/extensions/permessage_deflate/enabled.hpp`

---

## Target branch

Per repository guidance in `readme.md`, this series is based on and intended for `develop`.
