### PR TITLE
Fix examples build with Openssl 4.0

### DIFF
--- a/examples/print_client_tls/print_client_tls.cpp
+++ b/examples/print_client_tls/print_client_tls.cpp
@@ -84,13 +84,13 @@ bool verify_common_name(char const * hostname, X509 * cert) {
     }
     
     // Extract the CN field
-    X509_NAME_ENTRY * common_name_entry = X509_NAME_get_entry(X509_get_subject_name(cert), common_name_loc);
+    const X509_NAME_ENTRY * common_name_entry = X509_NAME_get_entry(X509_get_subject_name(cert), common_name_loc);
     if (common_name_entry == NULL) {
         return false;
     }
     
     // Convert the CN field to a C string
-    ASN1_STRING * common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
+    const ASN1_STRING * common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
     if (common_name_asn1 == NULL) {
         return false;
     }


### PR DESCRIPTION
From:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1138364


| /build/reproducible-path/websocketpp-0.8.2+git20250909/examples/print_client_tls/print_client_tls.cpp: In function â€˜bool verify_subject_alternative_name(const char*, X509*)â€™: | /build/reproducible-path/websocketpp-0.8.2+git20250909/examples/print_client_tls/print_client_tls.cpp:67:57: warning: comparison of integer expressions of different signedness: â€˜intâ€™ and â€˜size_tâ€™ {aka â€˜long unsigned intâ€™} [-Wsign-compare]
|    67 |         if (ASN1_STRING_length(current_name->d.dNSName) != strlen(dns_name)) {
|       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
| /build/reproducible-path/websocketpp-0.8.2+git20250909/examples/print_client_tls/print_client_tls.cpp: In function â€˜bool verify_common_name(const char*, X509*)â€™:
| /build/reproducible-path/websocketpp-0.8.2+git20250909/examples/print_client_tls/print_client_tls.cpp:87:62: error: invalid conversion from â€˜const X509_NAME_ENTRY*â€™ {aka â€˜const X509_name_entry_st*â€™} to â€˜X509_NAME_ENTRY*â€™ {aka â€˜X509_name_entry_st*â€™} [-fpermissive]
|    87 |     X509_NAME_ENTRY * common_name_entry = X509_NAME_get_entry(X509_get_subject_name(cert), common_name_loc);
|       |                                           ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|       |                                                              |
|       |                                                              const X509_NAME_ENTRY* {aka const X509_name_entry_st*}
| /build/reproducible-path/websocketpp-0.8.2+git20250909/examples/print_client_tls/print_client_tls.cpp:93:62: error: invalid conversion from â€˜const ASN1_STRING*â€™ {aka â€˜const asn1_string_st*â€™} to â€˜ASN1_STRING*â€™ {aka â€˜asn1_string_st*â€™} [-fpermissive]
|    93 |     ASN1_STRING * common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
|       |                                      ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
|       |                                                              |
|       |                                                              const ASN1_STRING* {aka const asn1_string_st*}
| /build/reproducible-path/websocketpp-0.8.2+git20250909/examples/print_client_tls/print_client_tls.cpp:101:46: warning: comparison of integer expressions of different signedness: â€˜intâ€™ and â€˜size_tâ€™ {aka â€˜long unsigned intâ€™} [-Wsign-compare]
|   101 |     if (ASN1_STRING_length(common_name_asn1) != strlen(common_name_str)) {
|       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
| make[3]: *** [examples/print_client_tls/CMakeFiles/print_client_tls.dir/build.make:82: examples/print_client_tls/CMakeFiles/print_client_tls.dir/print_client_tls.cpp.o] Error 1